### PR TITLE
Add ImmutableWitherMethodRule to PhpStan

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,10 +50,6 @@ jobs:
       matrix:
         php-version:
           - 7.1
-          - 7.2
-          - 7.4
-          - 8.0
-          - 8.1
 
     steps:
       - name: Checkout

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "squizlabs/php_codesniffer": "~3.5.3",
         "slevomat/coding-standard": "^6.0",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.5 || ^0.7",
-        "phpstan/phpstan": "^0.12",
+        "phpstan/phpstan": "^0.12.65",
         "phpstan/phpstan-strict-rules": "^0.12",
         "phpstan/phpstan-nette": "^0.12",
         "phpstan/phpstan-mockery": "^0.12"

--- a/phpstan-extension.neon
+++ b/phpstan-extension.neon
@@ -3,3 +3,7 @@ services:
         class: BrandEmbassyCodingStandard\PhpStan\Rules\Mockery\PostConditionsTraitUsedRule
         tags:
             - phpstan.rules.rule
+    -
+        class: BrandEmbassyCodingStandard\PhpStan\Rules\Method\ImmutableWitherMethodRule
+        tags:
+            - phpstan.rules.rule

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,6 @@
 includes:
     - vendor/phpstan/phpstan-strict-rules/rules.neon
+    - phpstan-extension.neon
 
 parameters:
     level: max
@@ -13,3 +14,6 @@ parameters:
         -
             message: '#Class BrandEmbassyCodingStandard\\PhpStan\\Rules\\Mockery\\PostConditionsTraitUsedRule implements generic interface PHPStan\\Rules\\Rule but does not specify its types: TNodeType#'
             path: src/BrandEmbassyCodingStandard/PhpStan/Rules/Mockery/PostConditionsTraitUsedRule.php
+        -
+            message: '#^Method with\w+\(\) is a mutable wither as (.*)\. The method should return modified clone of \$this\.$#'
+            path: src/BrandEmbassyCodingStandard/PhpStan/Rules/Method/__fixtures__/MutableWithersClass.php

--- a/src/BrandEmbassyCodingStandard/PhpStan/Rules/Method/ImmutableWitherMethodRule.php
+++ b/src/BrandEmbassyCodingStandard/PhpStan/Rules/Method/ImmutableWitherMethodRule.php
@@ -1,0 +1,92 @@
+<?php declare(strict_types = 1);
+
+namespace BrandEmbassyCodingStandard\PhpStan\Rules\Method;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\Node\Stmt\Return_;
+use PhpParser\NodeTraverser;
+use PhpParser\NodeVisitor\FindingVisitor;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use function preg_match;
+use function sprintf;
+
+/**
+ * @implements Rule<ClassMethod>
+ */
+class ImmutableWitherMethodRule implements Rule
+{
+    private const MESSAGE = 'Method %s() is a mutable wither as %s. The method should return modified clone of $this.';
+
+    /**
+     * @var NodeTraverser
+     */
+    private $nodeTraverser;
+
+    /**
+     * @var FindingVisitor
+     */
+    private $findingVisitor;
+
+
+    public function __construct()
+    {
+        $this->nodeTraverser = new NodeTraverser();
+        $this->findingVisitor = new FindingVisitor(function (Node $node): bool {
+            return true;
+        });
+
+        $this->nodeTraverser->addVisitor($this->findingVisitor);
+    }
+
+
+    public function getNodeType(): string
+    {
+        return ClassMethod::class;
+    }
+
+
+    /**
+     * @param ClassMethod $node
+     *
+     * @return string[]
+     */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        $methodName = $node->name->name;
+
+        if (preg_match('~^with[A-Z0-9]~', $methodName) === 0) {
+            return [];
+        }
+
+        if ($node->stmts === null) {
+            return [];
+        }
+
+        $this->nodeTraverser->traverse($node->stmts);
+
+        foreach ($this->findingVisitor->getFoundNodes() as $innerNode) {
+            if ($this->isReturnThisNode($innerNode)) {
+                return [sprintf(self::MESSAGE, $methodName, 'it returns $this')];
+            }
+        }
+
+        return [];
+    }
+
+
+    private function isReturnThisNode(Node $node): bool
+    {
+        if (!$node instanceof Return_) {
+            return false;
+        }
+
+        if ($node->expr instanceof Variable && $node->expr->name === 'this') {
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/src/BrandEmbassyCodingStandard/PhpStan/Rules/Method/ImmutableWitherMethodRuleTest.php
+++ b/src/BrandEmbassyCodingStandard/PhpStan/Rules/Method/ImmutableWitherMethodRuleTest.php
@@ -22,8 +22,12 @@ class ImmutableWitherMethodRuleTest extends RuleTestCase
             [__DIR__ . '/__fixtures__/MutableWithersClass.php'],
             [
                 [
+                    'Method withStringSetter() is a mutable wither as it calls a setter on $this. The method should return modified clone of $this.',
+                    25,
+                ],
+                [
                     'Method withString() is a mutable wither as it returns $this. The method should return modified clone of $this.',
-                    19,
+                    33,
                 ],
             ]
         );

--- a/src/BrandEmbassyCodingStandard/PhpStan/Rules/Method/ImmutableWitherMethodRuleTest.php
+++ b/src/BrandEmbassyCodingStandard/PhpStan/Rules/Method/ImmutableWitherMethodRuleTest.php
@@ -1,0 +1,40 @@
+<?php declare(strict_types = 1);
+
+namespace BrandEmbassyCodingStandard\PhpStan\Rules\Method;
+
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * @extends RuleTestCase<ImmutableWitherMethodRule>
+ */
+class ImmutableWitherMethodRuleTest extends RuleTestCase
+{
+    protected function getRule(): Rule
+    {
+        return new ImmutableWitherMethodRule();
+    }
+
+
+    public function testAnalyseMutableWithers(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/__fixtures__/MutableWithersClass.php'],
+            [
+                [
+                    'Method withString() is a mutable wither as it returns $this. The method should return modified clone of $this.',
+                    19,
+                ],
+            ]
+        );
+    }
+
+
+    public function testAnalyseImmutableWithers(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/__fixtures__/ImmutableWithersClass.php'],
+            []
+        );
+    }
+}

--- a/src/BrandEmbassyCodingStandard/PhpStan/Rules/Method/__fixtures__/ImmutableWithersClass.php
+++ b/src/BrandEmbassyCodingStandard/PhpStan/Rules/Method/__fixtures__/ImmutableWithersClass.php
@@ -16,10 +16,25 @@ final class ImmutableWithersClass
     }
 
 
+    public function setString(string $string): void
+    {
+        $this->string = $string;
+    }
+
+
     public function withString(string $string): self
     {
         $clone = clone $this;
         $clone->string = $string;
+
+        return $clone;
+    }
+
+
+    public function withStringSetter(string $string): self
+    {
+        $clone = clone $this;
+        $clone->setString($string);
 
         return $clone;
     }

--- a/src/BrandEmbassyCodingStandard/PhpStan/Rules/Method/__fixtures__/ImmutableWithersClass.php
+++ b/src/BrandEmbassyCodingStandard/PhpStan/Rules/Method/__fixtures__/ImmutableWithersClass.php
@@ -1,0 +1,32 @@
+<?php declare(strict_types = 1);
+
+namespace BrandEmbassyCodingStandard\PhpStan\Rules\Method\__fixtures__;
+
+final class ImmutableWithersClass
+{
+    /**
+     * @var string
+     */
+    private $string;
+
+
+    public function getString(): string
+    {
+        return $this->string;
+    }
+
+
+    public function withString(string $string): self
+    {
+        $clone = clone $this;
+        $clone->string = $string;
+
+        return $clone;
+    }
+
+
+    public function withPrefixedString(string $string): self
+    {
+        return $this->withString('prefix_' . $string);
+    }
+}

--- a/src/BrandEmbassyCodingStandard/PhpStan/Rules/Method/__fixtures__/MutableWithersClass.php
+++ b/src/BrandEmbassyCodingStandard/PhpStan/Rules/Method/__fixtures__/MutableWithersClass.php
@@ -1,0 +1,25 @@
+<?php declare(strict_types = 1);
+
+namespace BrandEmbassyCodingStandard\PhpStan\Rules\Method\__fixtures__;
+
+final class MutableWithersClass
+{
+    /**
+     * @var string
+     */
+    private $string;
+
+
+    public function getString(): string
+    {
+        return $this->string;
+    }
+
+
+    public function withString(string $string): self
+    {
+        $this->string = $string;
+
+        return $this;
+    }
+}

--- a/src/BrandEmbassyCodingStandard/PhpStan/Rules/Method/__fixtures__/MutableWithersClass.php
+++ b/src/BrandEmbassyCodingStandard/PhpStan/Rules/Method/__fixtures__/MutableWithersClass.php
@@ -16,6 +16,20 @@ final class MutableWithersClass
     }
 
 
+    public function setString(string $string): void
+    {
+        $this->string = $string;
+    }
+
+
+    public function withStringSetter(string $string): self
+    {
+        $this->setString($string);
+
+        return clone $this;
+    }
+
+
     public function withString(string $string): self
     {
         $this->string = $string;


### PR DESCRIPTION
See https://github.com/BrandEmbassy/developers-manifest/issues/643 for description of the issue, see BrandEmbassy/channel-integrations#194 for an example of application.

Just a basic check of mutable withers.

My idea is to have a rule that detects more and more unsafe mutable withers that we actually find in our code and can describe using AST. The rule written in such a ways that more cases can be added iteratively. Eg. this wither is still in our code (the check for it was already implemented in 2007989):

```php
    /**
     * @param mixed[] $data
     */
    public function withHtmlTemplate(
        string $templateFile,
        array $data = [],
        int $code = StatusCode::STATUS_200
    ): Response {
        $this->setHtml();

        return $this->htmlRenderer->render($this, $templateFile, $data)
            ->withStatus($code);
    }
```

You can add a search for setters in the current code (no open-closed principle atm, sorry, had a hard time getting it working):

```diff
        foreach ($this->findingVisitor->getFoundNodes() as $innerNode) {
            if ($this->isReturnThisNode($innerNode)) {
                return [sprintf(self::MESSAGE, $methodName, 'it returns $this')];
            }
+
+           if ($this->isCallingSetterOnThis($innerNode)) {
+               return [sprintf(self::MESSAGE, $methodName, 'it calls a setter on $this')];
+           }
        }
```

Not perfect, but I think that it will work for 99% of possible issues if we describe new cases for unsafe withers.