### PR TITLE
ImmutableWitherMethodRule: detect write access to own property

### DIFF
--- a/src/BrandEmbassyCodingStandard/PhpStan/Rules/Method/ImmutableWitherMethodRuleTest.php
+++ b/src/BrandEmbassyCodingStandard/PhpStan/Rules/Method/ImmutableWitherMethodRuleTest.php
@@ -29,6 +29,10 @@ class ImmutableWitherMethodRuleTest extends RuleTestCase
                     'Method withString() is a mutable wither as it returns $this. The method should return modified clone of $this.',
                     33,
                 ],
+                [
+                    'Method withStringAssignment() is a mutable wither as it writes to own property. The method should return modified clone of $this.',
+                    42,
+                ],
             ]
         );
     }

--- a/src/BrandEmbassyCodingStandard/PhpStan/Rules/Method/__fixtures__/MutableWithersClass.php
+++ b/src/BrandEmbassyCodingStandard/PhpStan/Rules/Method/__fixtures__/MutableWithersClass.php
@@ -32,8 +32,15 @@ final class MutableWithersClass
 
     public function withString(string $string): self
     {
-        $this->string = $string;
+        $clone = clone $this;
+        $clone->string = $string;
 
         return $this;
+    }
+
+
+    public function withStringAssignment(string $string): void
+    {
+        $this->string = $string;
     }
 }


### PR DESCRIPTION
During BrandEmbassy/channel-integrations#194 I've come across withers that were not returning a value and just wrote to a property (see https://github.com/BrandEmbassy/channel-integrations/pull/194/commits/067820d0bb60fd02a1a58f9fd19ef6ba42a82f8a). These mutable withers were not reported by the `ImmutableWitherMethodRule`:

```php
    public function withReplyToPlatformMessageId(?string $parentPlatformMessageId): void
    {
        $this->parentPlatformMessageId = $parentPlatformMessageId;
    }
```