### PR TITLE
Add PhpStan rule to ensure all tests are executed

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
     "scripts": {
         "phpcs": "vendor/bin/phpcs --standard=BrandEmbassyCodingStandard src --ignore='*/__fixtures__/*'",
         "phpcbf": "vendor/bin/phpcbf --standard=BrandEmbassyCodingStandard src --ignore='*/__fixtures__/*'",
-        "phpunit": "vendor/bin/phpunit src",
+        "phpunit": "vendor/bin/phpunit src --filter '/\\\\(?!__fixtures__)\\w+\\\\\\w+::/'",
         "phpstan": "vendor/bin/phpstan analyze -c phpstan.neon src --memory-limit=-1"
     },
     "minimum-stability": "dev",

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "squizlabs/php_codesniffer": "~3.5.3",
         "slevomat/coding-standard": "^6.0",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.5 || ^0.7",
-        "phpstan/phpstan": "^0.12.65",
+        "phpstan/phpstan": "^0.12.92",
         "phpstan/phpstan-strict-rules": "^0.12",
         "phpstan/phpstan-nette": "^0.12",
         "phpstan/phpstan-mockery": "^0.12"

--- a/phpstan-extension.neon
+++ b/phpstan-extension.neon
@@ -7,3 +7,7 @@ services:
         class: BrandEmbassyCodingStandard\PhpStan\Rules\Method\ImmutableWitherMethodRule
         tags:
             - phpstan.rules.rule
+    -
+        class: BrandEmbassyCodingStandard\PhpStan\Rules\Method\PhpUnitTestMethodRule
+        tags:
+            - phpstan.rules.rule

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -6,7 +6,7 @@ parameters:
     level: max
     excludes_analyse:
         - src/BrandEmbassyCodingStandard/Sniffs/TypeHints/TypeHintDeclarationSniff.php
-        - src/BrandEmbassyCodingStandard/Sniffs/Classes/__fixtures__
+        - src/BrandEmbassyCodingStandard/*/__fixtures__/*
     ignoreErrors:
         -
             message: '#Parameter \#1 \$node \(PhpParser\\Node\\Expr\\MethodCall\) of method BrandEmbassyCodingStandard\\PhpStan\\Rules\\Mockery\\PostConditionsTraitUsedRule::processNode\(\) should be contravariant with parameter \$node \(PhpParser\\Node\) of method PHPStan\\Rules\\Rule\<PhpParser\\Node\>::processNode\(\)#'
@@ -14,6 +14,3 @@ parameters:
         -
             message: '#Class BrandEmbassyCodingStandard\\PhpStan\\Rules\\Mockery\\PostConditionsTraitUsedRule implements generic interface PHPStan\\Rules\\Rule but does not specify its types: TNodeType#'
             path: src/BrandEmbassyCodingStandard/PhpStan/Rules/Mockery/PostConditionsTraitUsedRule.php
-        -
-            message: '#^Method with\w+\(\) is a mutable wither as (.*)\. The method should return modified clone of \$this\.$#'
-            path: src/BrandEmbassyCodingStandard/PhpStan/Rules/Method/__fixtures__/MutableWithersClass.php

--- a/src/BrandEmbassyCodingStandard/PhpStan/Rules/Method/PhpUnitTestMethodRule.php
+++ b/src/BrandEmbassyCodingStandard/PhpStan/Rules/Method/PhpUnitTestMethodRule.php
@@ -1,0 +1,87 @@
+<?php declare(strict_types = 1);
+
+namespace BrandEmbassyCodingStandard\PhpStan\Rules\Method;
+
+use PhpParser\Node;
+use PhpParser\Node\Stmt\Class_;
+use PhpParser\Node\Stmt\ClassMethod;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\ReflectionProvider;
+use PHPStan\Rules\Rule;
+use PHPUnit\Framework\TestCase;
+use function assert;
+use function preg_match;
+use function sprintf;
+use function strlen;
+use function substr;
+
+/**
+ * @implements Rule<ClassMethod>
+ */
+class PhpUnitTestMethodRule implements Rule
+{
+    private const TEST_CLASS_SUFFIX = 'Test';
+
+    /**
+     * @var ReflectionProvider
+     */
+    private $reflectionProvider;
+
+
+    public function __construct(ReflectionProvider $reflectionProvider)
+    {
+        $this->reflectionProvider = $reflectionProvider;
+    }
+
+
+    public function getNodeType(): string
+    {
+        return ClassMethod::class;
+    }
+
+
+    /**
+     * @param ClassMethod $node
+     *
+     * @return string[]
+     */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        $methodName = $node->name->name;
+
+        if (preg_match('~^test[A-Z0-9]~', $methodName) === 0) {
+            return [];
+        }
+
+        $classNode = $node->getAttribute('parent');
+        assert($classNode instanceof Class_);
+
+        $className = (string)$classNode->namespacedName;
+        if (!$this->reflectionProvider->hasClass($className)) {
+            return [sprintf('Vampire class error: cannot get reflection of class %s.', $className)];
+        }
+
+        $classReflection = $this->reflectionProvider->getClass($className);
+
+        $violations = [];
+        if (!$classReflection->isSubclassOf(TestCase::class)) {
+            $violationReason = sprintf('the class is not a %s', TestCase::class);
+            $violations[] = $this->getTestMethodViolation($className, $methodName, $violationReason);
+        }
+        if (substr($className, -strlen(self::TEST_CLASS_SUFFIX)) !== self::TEST_CLASS_SUFFIX) {
+            $violationReason = sprintf('the class is not suffixed %s', self::TEST_CLASS_SUFFIX);
+            $violations[] = $this->getTestMethodViolation($className, $methodName, $violationReason);
+        }
+        if (!$node->isPublic()) {
+            $violations[] = $this->getTestMethodViolation($className, $methodName, 'it is not public');
+        }
+
+        return $violations;
+    }
+
+
+    protected function getTestMethodViolation(string $className, string $methodName, string $reason): string
+    {
+        return sprintf('Method %s::%s() seems like a test method, but %s.', $className, $methodName, $reason);
+    }
+}

--- a/src/BrandEmbassyCodingStandard/PhpStan/Rules/Method/PhpUnitTestMethodRuleTest.php
+++ b/src/BrandEmbassyCodingStandard/PhpStan/Rules/Method/PhpUnitTestMethodRuleTest.php
@@ -1,0 +1,79 @@
+<?php declare(strict_types = 1);
+
+namespace BrandEmbassyCodingStandard\PhpStan\Rules\Method;
+
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * @extends RuleTestCase<PhpUnitTestMethodRule>
+ */
+class PhpUnitTestMethodRuleTest extends RuleTestCase
+{
+    protected function getRule(): Rule
+    {
+        return new PhpUnitTestMethodRule($this->createReflectionProvider());
+    }
+
+
+    public function testAnalyseTestClasses(): void
+    {
+        $this->analyse(
+            [
+                __DIR__ . '/__fixtures__/BadlyNamedTestClass.php',
+                __DIR__ . '/__fixtures__/NonPhpUnitTest.php',
+                __DIR__ . '/__fixtures__/PhpUnitTest.php',
+            ],
+            [
+                [
+                    'Method BrandEmbassyCodingStandard\PhpStan\Rules\Method\__fixtures__\BadlyNamedTestClass::testFunctionPublic() seems like a test method, but the class is not suffixed Test.',
+                    10,
+                ],
+                [
+                    'Method BrandEmbassyCodingStandard\PhpStan\Rules\Method\__fixtures__\BadlyNamedTestClass::testFunctionProtected() seems like a test method, but the class is not suffixed Test.',
+                    16,
+                ],
+                [
+                    'Method BrandEmbassyCodingStandard\PhpStan\Rules\Method\__fixtures__\BadlyNamedTestClass::testFunctionProtected() seems like a test method, but it is not public.',
+                    16,
+                ],
+                [
+                    'Method BrandEmbassyCodingStandard\PhpStan\Rules\Method\__fixtures__\BadlyNamedTestClass::testFunctionPrivate() seems like a test method, but the class is not suffixed Test.',
+                    22,
+                ],
+                [
+                    'Method BrandEmbassyCodingStandard\PhpStan\Rules\Method\__fixtures__\BadlyNamedTestClass::testFunctionPrivate() seems like a test method, but it is not public.',
+                    22,
+                ],
+                [
+                    'Method BrandEmbassyCodingStandard\PhpStan\Rules\Method\__fixtures__\NonPhpUnitTest::testFunctionPublic() seems like a test method, but the class is not a PHPUnit\Framework\TestCase.',
+                    9,
+                ],
+                [
+                    'Method BrandEmbassyCodingStandard\PhpStan\Rules\Method\__fixtures__\NonPhpUnitTest::testFunctionProtected() seems like a test method, but the class is not a PHPUnit\Framework\TestCase.',
+                    15,
+                ],
+                [
+                    'Method BrandEmbassyCodingStandard\PhpStan\Rules\Method\__fixtures__\NonPhpUnitTest::testFunctionProtected() seems like a test method, but it is not public.',
+                    15,
+                ],
+                [
+                    'Method BrandEmbassyCodingStandard\PhpStan\Rules\Method\__fixtures__\NonPhpUnitTest::testFunctionPrivate() seems like a test method, but the class is not a PHPUnit\Framework\TestCase.',
+                    21,
+                ],
+                [
+                    'Method BrandEmbassyCodingStandard\PhpStan\Rules\Method\__fixtures__\NonPhpUnitTest::testFunctionPrivate() seems like a test method, but it is not public.',
+                    21,
+                ],
+                [
+                    'Method BrandEmbassyCodingStandard\PhpStan\Rules\Method\__fixtures__\PhpUnitTest::testFunctionProtected() seems like a test method, but it is not public.',
+                    16,
+                ],
+                [
+                    'Method BrandEmbassyCodingStandard\PhpStan\Rules\Method\__fixtures__\PhpUnitTest::testFunctionPrivate() seems like a test method, but it is not public.',
+                    22,
+                ],
+            ]
+        );
+    }
+}

--- a/src/BrandEmbassyCodingStandard/PhpStan/Rules/Method/__fixtures__/BadlyNamedTestClass.php
+++ b/src/BrandEmbassyCodingStandard/PhpStan/Rules/Method/__fixtures__/BadlyNamedTestClass.php
@@ -1,0 +1,32 @@
+<?php declare(strict_types = 1);
+
+namespace BrandEmbassyCodingStandard\PhpStan\Rules\Method\__fixtures__;
+
+use PHPUnit\Framework\Assert;
+use PHPUnit\Framework\TestCase;
+
+final class BadlyNamedTestClass extends TestCase
+{
+    public function testFunctionPublic(): void
+    {
+        Assert::assertTrue(true);
+    }
+
+
+    protected function testFunctionProtected(): void
+    {
+        Assert::assertTrue(true);
+    }
+
+
+    private function testFunctionPrivate(): void
+    {
+        Assert::assertTrue(true);
+    }
+
+
+    public function nonTestFunction(): void
+    {
+        Assert::assertTrue(true);
+    }
+}

--- a/src/BrandEmbassyCodingStandard/PhpStan/Rules/Method/__fixtures__/NonPhpUnitTest.php
+++ b/src/BrandEmbassyCodingStandard/PhpStan/Rules/Method/__fixtures__/NonPhpUnitTest.php
@@ -1,0 +1,31 @@
+<?php declare(strict_types = 1);
+
+namespace BrandEmbassyCodingStandard\PhpStan\Rules\Method\__fixtures__;
+
+use PHPUnit\Framework\Assert;
+
+final class NonPhpUnitTest
+{
+    public function testFunctionPublic(): void
+    {
+        Assert::assertTrue(true);
+    }
+
+
+    protected function testFunctionProtected(): void
+    {
+        Assert::assertTrue(true);
+    }
+
+
+    private function testFunctionPrivate(): void
+    {
+        Assert::assertTrue(true);
+    }
+
+
+    public function nonTestFunction(): void
+    {
+        Assert::assertTrue(true);
+    }
+}

--- a/src/BrandEmbassyCodingStandard/PhpStan/Rules/Method/__fixtures__/PhpUnitTest.php
+++ b/src/BrandEmbassyCodingStandard/PhpStan/Rules/Method/__fixtures__/PhpUnitTest.php
@@ -1,0 +1,32 @@
+<?php declare(strict_types = 1);
+
+namespace BrandEmbassyCodingStandard\PhpStan\Rules\Method\__fixtures__;
+
+use PHPUnit\Framework\Assert;
+use PHPUnit\Framework\TestCase;
+
+final class PhpUnitTest extends TestCase
+{
+    public function testFunctionPublic(): void
+    {
+        Assert::assertTrue(true);
+    }
+
+
+    protected function testFunctionProtected(): void
+    {
+        Assert::assertTrue(true);
+    }
+
+
+    private function testFunctionPrivate(): void
+    {
+        Assert::assertTrue(true);
+    }
+
+
+    public function nonTestFunction(): void
+    {
+        Assert::assertTrue(true);
+    }
+}


### PR DESCRIPTION
Attempt to ensure that all test methods are executed (we had some issues in the past with non-executed tests because of silly mistakes).

All methods that are named `test*` must:
- be public
- be in a class named `*Test`
- be in a subclass of `\PHPUnit\Framework\TestCase`

Coming from our retrospective https://github.com/BrandEmbassy/retro/issues/422#issuecomment-973930353