### PR TITLE
Adding rule to forbid entity classes to be final

### DIFF
--- a/phpstan-extension.neon
+++ b/phpstan-extension.neon
@@ -11,3 +11,7 @@ services:
         class: BrandEmbassyCodingStandard\PhpStan\Rules\Method\PhpUnitTestMethodRule
         tags:
             - phpstan.rules.rule
+    -
+        class: BrandEmbassyCodingStandard\PhpStan\Rules\Doctrine\ORM\EntityNotFinalRule
+        tags:
+            - phpstan.rules.rule

--- a/src/BrandEmbassyCodingStandard/PhpStan/Rules/Doctrine/ORM/EntityNotFinalRule.php
+++ b/src/BrandEmbassyCodingStandard/PhpStan/Rules/Doctrine/ORM/EntityNotFinalRule.php
@@ -1,0 +1,72 @@
+<?php declare(strict_types = 1);
+
+namespace BrandEmbassyCodingStandard\PhpStan\Rules\Doctrine\ORM;
+
+use PhpParser\Node;
+use PHPStan\Analyser\Scope;
+use PHPStan\Node\InClassNode;
+use PHPStan\PhpDoc\ResolvedPhpDocBlock;
+use PHPStan\Reflection\ClassReflection;
+use PHPStan\Rules\Rule;
+use PHPStan\ShouldNotHappenException;
+use function sprintf;
+use function strpos;
+
+/**
+ * @implements Rule<InClassNode>
+ */
+class EntityNotFinalRule implements Rule
+{
+    public function getNodeType(): string
+    {
+        return InClassNode::class;
+    }
+
+
+    /**
+     * @return array<string>
+     */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        $classReflection = $scope->getClassReflection();
+        if ($classReflection === null) {
+            throw new ShouldNotHappenException();
+        }
+
+        if (!$classReflection->isFinalByKeyword()) {
+            return [];
+        }
+
+        $phpDoc = $classReflection->getResolvedPhpDoc();
+
+        if ($phpDoc === null) {
+            return [];
+        }
+
+        return $this->resolveBasedOnEntityAnnotation($phpDoc, $classReflection);
+    }
+
+
+    /**
+     * @return array<string>
+     */
+    private function resolveBasedOnEntityAnnotation(
+        ResolvedPhpDocBlock $phpDoc,
+        ClassReflection $classReflection
+    ): array {
+        foreach ($phpDoc->getPhpDocNodes() as $phpDocNode) {
+            foreach ($phpDocNode->getTagsByName('@ORM') as $phpDocTag) {
+                if (strpos((string)$phpDocTag, '@ORM \Entity(') === 0) {
+                    return [
+                        sprintf(
+                            'Entity class %s is final which can cause problems with proxies.',
+                            $classReflection->getDisplayName()
+                        ),
+                    ];
+                }
+            }
+        }
+
+        return [];
+    }
+}

--- a/src/BrandEmbassyCodingStandard/PhpStan/Rules/Doctrine/ORM/EntityNotFinalRuleTest.php
+++ b/src/BrandEmbassyCodingStandard/PhpStan/Rules/Doctrine/ORM/EntityNotFinalRuleTest.php
@@ -1,0 +1,40 @@
+<?php declare(strict_types = 1);
+
+namespace BrandEmbassyCodingStandard\PhpStan\Rules\Doctrine\ORM;
+
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * @extends RuleTestCase<EntityNotFinalRule>
+ */
+final class EntityNotFinalRuleTest extends RuleTestCase
+{
+    protected function getRule(): Rule
+    {
+        return new EntityNotFinalRule();
+    }
+
+
+    public function testCheckingIfEntityIsNotFinal(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/__fixtures__/FinalEntityClass.php'],
+            [
+                [
+                    'Entity class BrandEmbassyCodingStandard\PhpStan\Rules\Doctrine\ORM\__fixtures__\FinalEntityClass is final which can cause problems with proxies.',
+                    9,
+                ],
+            ]
+        );
+    }
+
+
+    public function testCheckingThatAnyOtherClassCanBeFinal(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/__fixtures__/FinalClass.php'],
+            []
+        );
+    }
+}

--- a/src/BrandEmbassyCodingStandard/PhpStan/Rules/Doctrine/ORM/__fixtures__/FinalClass.php
+++ b/src/BrandEmbassyCodingStandard/PhpStan/Rules/Doctrine/ORM/__fixtures__/FinalClass.php
@@ -1,0 +1,7 @@
+<?php declare(strict_types = 1);
+
+namespace BrandEmbassyCodingStandard\PhpStan\Rules\Doctrine\ORM\__fixtures__;
+
+final class FinalClass
+{
+}

--- a/src/BrandEmbassyCodingStandard/PhpStan/Rules/Doctrine/ORM/__fixtures__/FinalEntityClass.php
+++ b/src/BrandEmbassyCodingStandard/PhpStan/Rules/Doctrine/ORM/__fixtures__/FinalEntityClass.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types = 1);
+
+namespace BrandEmbassyCodingStandard\PhpStan\Rules\Doctrine\ORM\__fixtures__;
+
+/**
+ * @ORM\Entity(repositoryClass="FinalEntityClassRepository")
+ * @ORM\Table(name="be_final_entity_class")
+ */
+final class FinalEntityClass
+{
+}


### PR DESCRIPTION
The best thing would be to add doctrine extension for phpstan (`phpstan/phpstan-doctrine`) but there are quite a lot of issues to fix in that case. So I prepared just the final class rule to avoid such a mistake for now.