### PR TITLE
Mark dg/bypass-finals as conflicting package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,9 @@
             "vendor/squizlabs/php_codesniffer/src/Util/Tokens.php"
         ]
     },
+    "conflict": {
+        "dg/bypass-finals": "*"
+    },
     "require": {
         "php": "^7.1 || ^8.0",
         "squizlabs/php_codesniffer": "~3.5.3",


### PR DESCRIPTION
Suggestion for an update of #60 with prohibiting the use of `dg/bypass-finals` package