### PR TITLE
Set PHP 7.1 for code sniffer when running on this repo

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,8 +42,8 @@
         "mockery/mockery": "^1.3"
     },
     "scripts": {
-        "phpcs": "vendor/bin/phpcs --standard=BrandEmbassyCodingStandard src --ignore='*/__fixtures__/*' --runtime-set php_version 7.1",
-        "phpcbf": "vendor/bin/phpcbf --standard=BrandEmbassyCodingStandard src --ignore='*/__fixtures__/*' --runtime-set php_version 7.1",
+        "phpcs": "vendor/bin/phpcs --standard=BrandEmbassyCodingStandard src --ignore='*/__fixtures__/*' --runtime-set php_version 70100",
+        "phpcbf": "vendor/bin/phpcbf --standard=BrandEmbassyCodingStandard src --ignore='*/__fixtures__/*' --runtime-set php_version 70100",
         "phpunit": "vendor/bin/phpunit src --filter '/\\\\(?!__fixtures__)\\w+\\\\\\w+::/'",
         "phpstan": "vendor/bin/phpstan analyze -c phpstan.neon src --memory-limit=-1"
     },

--- a/composer.json
+++ b/composer.json
@@ -42,8 +42,8 @@
         "mockery/mockery": "^1.3"
     },
     "scripts": {
-        "phpcs": "vendor/bin/phpcs --standard=BrandEmbassyCodingStandard src --ignore='*/__fixtures__/*'",
-        "phpcbf": "vendor/bin/phpcbf --standard=BrandEmbassyCodingStandard src --ignore='*/__fixtures__/*'",
+        "phpcs": "vendor/bin/phpcs --standard=BrandEmbassyCodingStandard src --ignore='*/__fixtures__/*' --runtime-set php_version 7.1",
+        "phpcbf": "vendor/bin/phpcbf --standard=BrandEmbassyCodingStandard src --ignore='*/__fixtures__/*' --runtime-set php_version 7.1",
         "phpunit": "vendor/bin/phpunit src --filter '/\\\\(?!__fixtures__)\\w+\\\\\\w+::/'",
         "phpstan": "vendor/bin/phpstan analyze -c phpstan.neon src --memory-limit=-1"
     },


### PR DESCRIPTION
As this package supports PHP versions ^7.1 || ^8.0 we should check standards for it it the lowest supported version for easier development.

Now, for example, when developing this package and running `composer phpcbf` on locally installed PHP 8.0, it will not add type-hinting to properties.

---

Format explained in https://github.com/squizlabs/PHP_CodeSniffer/wiki/Configuration-Options#setting-the-php-version

![image](https://user-images.githubusercontent.com/10008612/155336759-db41397e-f230-43ac-a57d-41dcad50c44f.png)
