### PR TITLE
Require arrow functions instead of one-line Closures

### DIFF
--- a/src/BrandEmbassyCodingStandard/ruleset.xml
+++ b/src/BrandEmbassyCodingStandard/ruleset.xml
@@ -379,6 +379,9 @@
     <!-- Prohibits multiple traits separated by commas in one use statement -->
     <rule ref="SlevomatCodingStandard.Functions.UselessParameterDefaultValue"/>
 
+    <!-- Requires arrow functions for one-line Closures -->
+    <rule ref="SlevomatCodingStandard.Functions.RequireArrowFunction" />
+
     <!-- Disallows implicit array creation -->
     <rule ref="SlevomatCodingStandard.Arrays.DisallowImplicitArrayCreation"/>
 


### PR DESCRIPTION
In PHP 7.4, arrow functions are supported. Those are usable only instead of anonymous functions that just return an expression. Of course, if you run the rule with PHP < 7.4 it will not be applied.

They have access to the current scope - i.e. you don't need to use `use ($someVariable)` as all variables from current scope are behaving as if they were used. This makes the fix a bit risky (but really just a bit)

Example of how it work in real life: https://github.com/BrandEmbassy/channel-integrations/pull/787