### PR TITLE
Require trailing comma in multiline function calls

### DIFF
--- a/src/BrandEmbassyCodingStandard/ruleset.xml
+++ b/src/BrandEmbassyCodingStandard/ruleset.xml
@@ -379,6 +379,9 @@
     <!-- Prohibits multiple traits separated by commas in one use statement -->
     <rule ref="SlevomatCodingStandard.Functions.UselessParameterDefaultValue"/>
 
+    <!-- Requires trailing comma in multiline function calls -->
+    <rule ref="SlevomatCodingStandard.Functions.TrailingCommaInCall" />
+
     <!-- Disallows implicit array creation -->
     <rule ref="SlevomatCodingStandard.Arrays.DisallowImplicitArrayCreation"/>
 


### PR DESCRIPTION
Makes this:

```php
         $request = RequestBuilder::create(
             HttpMethod::GET,
             '/apple-business/app/message-template/template/' . AuthenticationTester::TEMPLATE_ID,
             []
         );
```

into this:

```php
         $request = RequestBuilder::create(
             HttpMethod::GET,
             '/apple-business/app/message-template/template/' . AuthenticationTester::TEMPLATE_ID,
             [],
         );
```

---

Commas after the last parameter in function or method call make adding a new parameter easier and result in a cleaner versioning diff. This sniff enforces trailing commas in multi-line calls.

It is enabled for PHP versions 7.3 or higher.