### PR TITLE
Require specific arrow function formatting

### DIFF
--- a/src/BrandEmbassyCodingStandard/ruleset.xml
+++ b/src/BrandEmbassyCodingStandard/ruleset.xml
@@ -382,6 +382,13 @@
     <!-- Requires arrow functions for one-line Closures -->
     <rule ref="SlevomatCodingStandard.Functions.RequireArrowFunction" />
 
+    <!-- Arrow function formatting -->
+    <rule ref="SlevomatCodingStandard.Functions.ArrowFunctionDeclaration">
+        <properties>
+            <property name="spacesCountAfterKeyword" value="0"/>
+        </properties>
+    </rule>
+
     <!-- Requires trailing comma in multiline function calls -->
     <rule ref="SlevomatCodingStandard.Functions.TrailingCommaInCall" />
 


### PR DESCRIPTION
Adds rule for arrow function formatting:

```php
fn(int $number) => $number * 2
```

---

this formatting is the default in PhpStorm (so autoformatting works as expected without any tweaks)