### PR TITLE
Add PhpStan PHPUnit extension

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,13 +28,14 @@
     },
     "require": {
         "php": "^7.1 || ^8.0",
-        "squizlabs/php_codesniffer": "~3.5.3",
-        "slevomat/coding-standard": "^6.0",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.5 || ^0.7",
         "phpstan/phpstan": "^0.12.92",
-        "phpstan/phpstan-strict-rules": "^0.12",
+        "phpstan/phpstan-mockery": "^0.12",
         "phpstan/phpstan-nette": "^0.12",
-        "phpstan/phpstan-mockery": "^0.12"
+        "phpstan/phpstan-phpunit": "^0.12",
+        "phpstan/phpstan-strict-rules": "^0.12",
+        "slevomat/coding-standard": "^6.0",
+        "squizlabs/php_codesniffer": "~3.5.3"
     },
     "require-dev": {
         "roave/security-advisories": "dev-master",
@@ -51,6 +52,10 @@
     "prefer-stable": true,
     "config": {
         "sort-packages": true,
+        "lock": false,
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true
+        },
         "process-timeout": 1200
     }
 }

--- a/default-phpstan.neon
+++ b/default-phpstan.neon
@@ -2,6 +2,7 @@ includes:
     - ../../../vendor/phpstan/phpstan-strict-rules/rules.neon
     - ../../../vendor/phpstan/phpstan-nette/extension.neon
     - ../../../vendor/phpstan/phpstan-mockery/extension.neon
+    - ../../../vendor/phpstan/phpstan-phpunit/extension.neon
     - ../../../vendor/brandembassy/coding-standard/phpstan-extension.neon
 
 parameters:

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,8 @@
 includes:
     - vendor/phpstan/phpstan-strict-rules/rules.neon
+    - vendor/phpstan/phpstan-nette/extension.neon
+    - vendor/phpstan/phpstan-mockery/extension.neon
+    - vendor/phpstan/phpstan-phpunit/extension.neon
     - phpstan-extension.neon
 
 parameters:


### PR DESCRIPTION
PHPUnit extension helps PhpStan understan code assertions in tests. Idea from https://github.com/BrandEmbassy/platform-domain-types/pull/255

For example, when running `Assert::assertInstanceOf(MyClass:name, $object)` PhpStan will understand that `$object` must be of type `MyClass`.

This allows us to reduce redundant `assert()` calls in tests and use `Assert::assertInstanceOf()` instead (which is better in tests as it is always executed and produces an assertion fail rather than error).

Additionally, the extension will improve the static analysis in other ways.

---

It will require some code changes after upgrade, which is normal with CS upgrades (eg. channel-integrations monorepo reported 15 new errors, mostly redundant `assert()` calls). I suggest releasing it as a MINOR version.