### PR TITLE
Update phpstan and phpstan extensions, require composer-runtime-api ^2.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,12 +28,13 @@
     },
     "require": {
         "php": "^7.4 || >=8.1",
+        "composer-runtime-api": "^2.2",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.5 || ^0.7",
-        "phpstan/phpstan": "^0.12.92",
-        "phpstan/phpstan-mockery": "^0.12",
-        "phpstan/phpstan-nette": "^0.12",
-        "phpstan/phpstan-phpunit": "^0.12",
-        "phpstan/phpstan-strict-rules": "^0.12",
+        "phpstan/phpstan": "^1.8",
+        "phpstan/phpstan-mockery": "^1.1",
+        "phpstan/phpstan-nette": "^1.0",
+        "phpstan/phpstan-phpunit": "^1.1",
+        "phpstan/phpstan-strict-rules": "^1.4",
         "slevomat/coding-standard": "^6.0",
         "squizlabs/php_codesniffer": "~3.5.3"
     },

--- a/default-phpstan.neon
+++ b/default-phpstan.neon
@@ -4,6 +4,10 @@ includes:
     - ../../../vendor/phpstan/phpstan-mockery/extension.neon
     - ../../../vendor/phpstan/phpstan-phpunit/extension.neon
     - ../../../vendor/brandembassy/coding-standard/phpstan-extension.neon
+    # TODO: Rewrite all phpstan rules in such a way that the node connecting visitor is no longer required
+    # TODO: Currently, \BrandEmbassyCodingStandard\PhpStan\Rules\Method\PhpUnitTestMethodRule retrieves
+    # TODO: attribute 'parent', which is provided by the node connecting visitor
+    - ../../../vendor/brandembassy/coding-standard/phpstan-node-connecting-visitor.neon
 
 parameters:
     level: max

--- a/phpstan-node-connecting-visitor.neon
+++ b/phpstan-node-connecting-visitor.neon
@@ -1,0 +1,3 @@
+conditionalTags:
+    PhpParser\NodeVisitor\NodeConnectingVisitor:
+        phpstan.parser.richParserNodeVisitor: true

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -4,14 +4,15 @@ includes:
     - vendor/phpstan/phpstan-mockery/extension.neon
     - vendor/phpstan/phpstan-phpunit/extension.neon
     - phpstan-extension.neon
+    # TODO: Rewrite all phpstan rules in such a way that the node connecting visitor is no longer required
+    # TODO: Currently, \BrandEmbassyCodingStandard\PhpStan\Rules\Method\PhpUnitTestMethodRule retrieves
+    # TODO: attribute 'parent', which is provided by the node connecting visitor
+    - ./phpstan-node-connecting-visitor.neon
 
 parameters:
     level: max
 
-    featureToggles:
-        finalByPhpDocTag: true
-
-    excludes_analyse:
+    excludePaths:
         - src/BrandEmbassyCodingStandard/Sniffs/TypeHints/TypeHintDeclarationSniff.php
         - src/BrandEmbassyCodingStandard/*/__fixtures__/*
     ignoreErrors:

--- a/src/BrandEmbassyCodingStandard/PhpStan/Rules/Method/PhpUnitTestMethodRuleTest.php
+++ b/src/BrandEmbassyCodingStandard/PhpStan/Rules/Method/PhpUnitTestMethodRuleTest.php
@@ -76,4 +76,13 @@ class PhpUnitTestMethodRuleTest extends RuleTestCase
             ],
         );
     }
+
+
+    /**
+     * @return string[]
+     */
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [];
+    }
 }


### PR DESCRIPTION
- Updated phpstan and all phpstan extensions
- New phpstan has dependency on `Composer\Autoload\ClassLoader::getRegisteredLoaders()`, which is available from the 2.x branch
  -  The recommended approach to constraining composer version is to use `composer-runtime-api` or `composer-plugin-api` constraint