### PR TITLE
9.x beta update code sniffer and coding standard

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,7 @@
         }
     ],
     "autoload": {
+        "files": [ "constants.php" ],
         "psr-4": {
             "BrandEmbassyCodingStandard\\": "src/BrandEmbassyCodingStandard"
         },
@@ -35,8 +36,8 @@
         "phpstan/phpstan-nette": "^1.0",
         "phpstan/phpstan-phpunit": "^1.1",
         "phpstan/phpstan-strict-rules": "^1.4",
-        "slevomat/coding-standard": "^6.0",
-        "squizlabs/php_codesniffer": "~3.5.3"
+        "slevomat/coding-standard": "^8.5",
+        "squizlabs/php_codesniffer": "^3.7"
     },
     "require-dev": {
         "roave/security-advisories": "dev-master",

--- a/constants.php
+++ b/constants.php
@@ -1,0 +1,13 @@
+<?php declare(strict_types = 1);
+
+// phpstan expects these constants to be an integer, but cs defines it as string
+// see vendor/squizlabs/php_codesniffer/src/Util/Tokens.php
+// Its hard to tell if this is a phpstan bug due to working with php8 constants in php7.4 project,
+// or if its a cs bug for declaring them as strings when in php8 they are integers
+if (defined('T_READONLY') === false) {
+    define('T_READONLY', 327);
+}
+
+if (defined('T_MATCH') === false) {
+    define('T_MATCH', 306);
+}

--- a/src/BrandEmbassyCodingStandard/ruleset.xml
+++ b/src/BrandEmbassyCodingStandard/ruleset.xml
@@ -171,6 +171,7 @@
     <!-- Require strict types declaration and its format -->
     <rule ref="SlevomatCodingStandard.TypeHints.DeclareStrictTypes">
         <properties>
+            <property name="declareOnFirstLine" value="1"/>
             <property name="newlinesCountBetweenOpenTagAndDeclare" value="0"/>
             <property name="newlinesCountAfterDeclare" value="2"/>
             <property name="spacesCountAroundEqualsSign" value="1"/>
@@ -234,9 +235,6 @@
 
     <!-- Requires use of null coalesce operator when possible -->
     <rule ref="SlevomatCodingStandard.ControlStructures.RequireNullCoalesceOperator"/>
-
-    <!-- Forbid dead code -->
-    <rule ref="SlevomatCodingStandard.Classes.UnusedPrivateElements"/>
 
     <!-- Forbid unused use statements -->
     <rule ref="SlevomatCodingStandard.Namespaces.UnusedUses">
@@ -390,7 +388,7 @@
     </rule>
 
     <!-- Requires trailing comma in multiline function calls -->
-    <rule ref="SlevomatCodingStandard.Functions.TrailingCommaInCall" />
+    <rule ref="SlevomatCodingStandard.Functions.RequireTrailingCommaInCall" />
 
     <!-- Disallows implicit array creation -->
     <rule ref="SlevomatCodingStandard.Arrays.DisallowImplicitArrayCreation"/>


### PR DESCRIPTION
- Updated code sniffer and coding standard
- Added compatibility fix between phpstan / code sniffer via `constants.php` (see comment in file for more information)
- Modified php require to use `>=` for php `7.4` based on suggestion from @dominikvoda