### PR TITLE
9.x temporarily disable node connecting visitor

### DIFF
--- a/default-phpstan.neon
+++ b/default-phpstan.neon
@@ -7,7 +7,7 @@ includes:
     # TODO: Rewrite all phpstan rules in such a way that the node connecting visitor is no longer required
     # TODO: Currently, \BrandEmbassyCodingStandard\PhpStan\Rules\Method\PhpUnitTestMethodRule retrieves
     # TODO: attribute 'parent', which is provided by the node connecting visitor
-    - ../../../vendor/brandembassy/coding-standard/phpstan-node-connecting-visitor.neon
+    # - ../../../vendor/brandembassy/coding-standard/phpstan-node-connecting-visitor.neon
 
 parameters:
     level: max

--- a/phpstan-extension.neon
+++ b/phpstan-extension.neon
@@ -7,7 +7,9 @@ services:
         class: BrandEmbassyCodingStandard\PhpStan\Rules\Method\ImmutableWitherMethodRule
         tags:
             - phpstan.rules.rule
-    -
-        class: BrandEmbassyCodingStandard\PhpStan\Rules\Method\PhpUnitTestMethodRule
-        tags:
-            - phpstan.rules.rule
+
+# TODO: Rule is disabled until it is rewritten without requiring node connecting visitor to speed up builds in ci
+#    -
+#        class: BrandEmbassyCodingStandard\PhpStan\Rules\Method\PhpUnitTestMethodRule
+#        tags:
+#            - phpstan.rules.rule

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -7,7 +7,7 @@ includes:
     # TODO: Rewrite all phpstan rules in such a way that the node connecting visitor is no longer required
     # TODO: Currently, \BrandEmbassyCodingStandard\PhpStan\Rules\Method\PhpUnitTestMethodRule retrieves
     # TODO: attribute 'parent', which is provided by the node connecting visitor
-    - ./phpstan-node-connecting-visitor.neon
+    # - ./phpstan-node-connecting-visitor.neon
 
 parameters:
     level: max


### PR DESCRIPTION
This change is only temporary so that we can test if node connecting visitor is really the reason for the performance slowdown in the CI