### PR TITLE
Rewrite PhpUnitTestMethodRule to not rely on NodeConnectingVisitor

### DIFF
--- a/default-phpstan.neon
+++ b/default-phpstan.neon
@@ -4,10 +4,6 @@ includes:
     - ../../../vendor/phpstan/phpstan-mockery/extension.neon
     - ../../../vendor/phpstan/phpstan-phpunit/extension.neon
     - ../../../vendor/brandembassy/coding-standard/phpstan-extension.neon
-    # TODO: Rewrite all phpstan rules in such a way that the node connecting visitor is no longer required
-    # TODO: Currently, \BrandEmbassyCodingStandard\PhpStan\Rules\Method\PhpUnitTestMethodRule retrieves
-    # TODO: attribute 'parent', which is provided by the node connecting visitor
-    # - ../../../vendor/brandembassy/coding-standard/phpstan-node-connecting-visitor.neon
 
 parameters:
     level: max

--- a/phpstan-extension.neon
+++ b/phpstan-extension.neon
@@ -8,8 +8,7 @@ services:
         tags:
             - phpstan.rules.rule
 
-# TODO: Rule is disabled until it is rewritten without requiring node connecting visitor to speed up builds in ci
-#    -
-#        class: BrandEmbassyCodingStandard\PhpStan\Rules\Method\PhpUnitTestMethodRule
-#        tags:
-#            - phpstan.rules.rule
+    -
+        class: BrandEmbassyCodingStandard\PhpStan\Rules\Method\PhpUnitTestMethodRule
+        tags:
+            - phpstan.rules.rule

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -4,10 +4,6 @@ includes:
     - vendor/phpstan/phpstan-mockery/extension.neon
     - vendor/phpstan/phpstan-phpunit/extension.neon
     - phpstan-extension.neon
-    # TODO: Rewrite all phpstan rules in such a way that the node connecting visitor is no longer required
-    # TODO: Currently, \BrandEmbassyCodingStandard\PhpStan\Rules\Method\PhpUnitTestMethodRule retrieves
-    # TODO: attribute 'parent', which is provided by the node connecting visitor
-    # - ./phpstan-node-connecting-visitor.neon
 
 parameters:
     level: max

--- a/src/BrandEmbassyCodingStandard/PhpStan/Rules/Method/PhpUnitTestMethodRule.php
+++ b/src/BrandEmbassyCodingStandard/PhpStan/Rules/Method/PhpUnitTestMethodRule.php
@@ -3,13 +3,11 @@
 namespace BrandEmbassyCodingStandard\PhpStan\Rules\Method;
 
 use PhpParser\Node;
-use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassMethod;
 use PHPStan\Analyser\Scope;
-use PHPStan\Reflection\ReflectionProvider;
+use PHPStan\Reflection\ClassReflection;
 use PHPStan\Rules\Rule;
 use PHPUnit\Framework\TestCase;
-use function assert;
 use function preg_match;
 use function sprintf;
 use function strlen;
@@ -21,14 +19,6 @@ use function substr;
 class PhpUnitTestMethodRule implements Rule
 {
     private const TEST_CLASS_SUFFIX = 'Test';
-
-    private ReflectionProvider $reflectionProvider;
-
-
-    public function __construct(ReflectionProvider $reflectionProvider)
-    {
-        $this->reflectionProvider = $reflectionProvider;
-    }
 
 
     public function getNodeType(): string
@@ -50,15 +40,13 @@ class PhpUnitTestMethodRule implements Rule
             return [];
         }
 
-        $classNode = $node->getAttribute('parent');
-        assert($classNode instanceof Class_);
-
-        $className = (string)$classNode->namespacedName;
-        if (!$this->reflectionProvider->hasClass($className)) {
-            return [sprintf('Vampire class error: cannot get reflection of class %s.', $className)];
+        if (!$scope->isInClass()) {
+            return [];
         }
 
-        $classReflection = $this->reflectionProvider->getClass($className);
+        /** @var ClassReflection $classReflection */
+        $classReflection = $scope->getClassReflection();
+        $className = $classReflection->getName();
 
         $violations = [];
         if (!$classReflection->isSubclassOf(TestCase::class)) {

--- a/src/BrandEmbassyCodingStandard/PhpStan/Rules/Method/PhpUnitTestMethodRuleTest.php
+++ b/src/BrandEmbassyCodingStandard/PhpStan/Rules/Method/PhpUnitTestMethodRuleTest.php
@@ -12,7 +12,7 @@ class PhpUnitTestMethodRuleTest extends RuleTestCase
 {
     protected function getRule(): Rule
     {
-        return new PhpUnitTestMethodRule($this->createReflectionProvider());
+        return new PhpUnitTestMethodRule();
     }
 
 
@@ -75,14 +75,5 @@ class PhpUnitTestMethodRuleTest extends RuleTestCase
                 ],
             ],
         );
-    }
-
-
-    /**
-     * @return string[]
-     */
-    public static function getAdditionalConfigFiles(): array
-    {
-        return [];
     }
 }


### PR DESCRIPTION
This PR removes technical debt by rewriting the `PhpUnitTestMethodRule` so that it does not rely on `NodeConnectingVisitor` to get the parent node of `ClassMethod` node via `$node->getAttribute('parent');`