### PR TITLE
Exclude Squiz.Commenting.VariableComment.VarOrder because of rule conflict

### DIFF
--- a/src/BrandEmbassyCodingStandard/ruleset.xml
+++ b/src/BrandEmbassyCodingStandard/ruleset.xml
@@ -475,6 +475,8 @@
         <exclude name="Squiz.Commenting.VariableComment.IncorrectVarType"/>
         <!-- Checked by SlevomatCodingStandard.TypeHints sniffs -->
         <exclude name="Squiz.Commenting.VariableComment.Missing"/>
+        <!-- In conflict with annotationsGroups in SlevomatCodingStandard.Commenting.DocCommentSpacing -->
+        <exclude name="Squiz.Commenting.VariableComment.VarOrder"/>
     </rule>
 
     <!-- Force rules for function argument spacing -->


### PR DESCRIPTION
Rules `Squiz.Commenting.VariableComment.VarOrder` and `SlevomatCodingStandard.Commenting.DocCommentSpacing` are currently in conflict (see https://github.com/BrandEmbassy/channel-integrations/pull/1652#issuecomment-1333686149). Both of these annotations are violating our rules:

```php
    /**
     * @phpcsSuppress SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint
     *
     * @var array<string, string>
     */
    protected static $errorNames = [...]
```

```php
    /**
     * @var array<string, string>
     *
     * @phpcsSuppress SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint
     */
    protected static $errorNames = [...]
```

I'm proposing to exclude `Squiz.Commenting.VariableComment.VarOrder` and release this as a PATCH version.