### PR TITLE
DE-121547 Upgrade rector and phpstan to 2.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,16 +31,16 @@
         "php": ">=8.1",
         "composer-runtime-api": "^2.2",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.5 || ^0.7 || ^1.0",
-        "phpstan/phpstan": "^1.11.6",
-        "phpstan/phpstan-mockery": "^1.1",
-        "phpstan/phpstan-nette": "^1.3.0",
-        "phpstan/phpstan-phpunit": "^1.4.0",
-        "phpstan/phpstan-strict-rules": "^1.6.0",
-        "rector/rector": "^1.2.0",
+        "phpstan/phpstan": " ^2.0",
+        "phpstan/phpstan-mockery": " ^2.0",
+        "phpstan/phpstan-nette": " ^2.0",
+        "phpstan/phpstan-phpunit": " ^2.0",
+        "phpstan/phpstan-strict-rules": " ^2.0",
+        "rector/rector": " ^2.0",
         "slevomat/coding-standard": "^8.15.0",
         "squizlabs/php_codesniffer": "^3.9.2",
         "symplify/easy-coding-standard": "^12.1.14",
-        "tomasvotruba/cognitive-complexity": "^0.2.3"
+        "tomasvotruba/cognitive-complexity": " ^1.0"
     },
     "require-dev": {
         "mockery/mockery": "^1.5",

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,2 +1,61 @@
 parameters:
 	ignoreErrors:
+		-
+			message: '#^PHPDoc tag @var with type class\-string\|null is not subtype of type string\.$#'
+			identifier: varTag.type
+			count: 1
+			path: src/BrandEmbassyCodingStandard/Rector/MabeEnumMethodCallToEnumConstRector/ClassNameProvider.php
+
+		-
+			message: '#^Parameter \#2 \$stackPtr of method PHP_CodeSniffer\\Files\\File\:\:addFixableError\(\) expects int, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/BrandEmbassyCodingStandard/Sniffs/Classes/TraitUsePositionSniff.php
+
+		-
+			message: '#^Binary operation "\-" between mixed and mixed results in an error\.$#'
+			identifier: binaryOp.invalid
+			count: 1
+			path: src/BrandEmbassyCodingStandard/Sniffs/Classes/TraitUseSpacingSniff.php
+
+		-
+			message: '#^Parameter \#2 \$tokens of method BrandEmbassyCodingStandard\\Sniffs\\Classes\\TraitUseSpacingSniff\:\:getRequiredLinesCountAfterLastUse\(\) expects array\<int, array\<mixed\>\>, array given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/BrandEmbassyCodingStandard/Sniffs/Classes/TraitUseSpacingSniff.php
+
+		-
+			message: '#^Parameter \#2 \$sniffProperties of static method SlevomatCodingStandard\\Sniffs\\TestCase\:\:checkFile\(\) expects array\<string, array\<int\|string, bool\|int\|string\|null\>\|bool\|int\|string\>, array\<int\> given\.$#'
+			identifier: argument.type
+			count: 3
+			path: src/BrandEmbassyCodingStandard/Sniffs/Classes/TraitUseSpacingSniffTest.php
+
+		-
+			message: '#^Parameter \#2 \$subject of function preg_match expects string, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/BrandEmbassyCodingStandard/Sniffs/Commenting/CreateMockFunctionReturnTypeOrderSniff.php
+
+		-
+			message: '#^Parameter \#4 \$startPointer of static method SlevomatCodingStandard\\Helpers\\TokenHelper\:\:findNextContent\(\) expects int, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/BrandEmbassyCodingStandard/Sniffs/Commenting/CreateMockFunctionReturnTypeOrderSniff.php
+
+		-
+			message: '#^Parameter \#1 \$string of function strtolower expects string, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/BrandEmbassyCodingStandard/Sniffs/ForbiddenElseStatementSniff.php
+
+		-
+			message: '#^Binary operation "\-" between mixed and 1 results in an error\.$#'
+			identifier: binaryOp.invalid
+			count: 1
+			path: src/BrandEmbassyCodingStandard/Sniffs/WhiteSpace/BlankLineBeforeReturnSniff.php
+
+		-
+			message: '#^Binary operation "\-" between mixed and 1 results in an error\.$#'
+			identifier: binaryOp.invalid
+			count: 1
+			path: src/BrandEmbassyCodingStandard/Sniffs/WhiteSpace/BlankLineBeforeThrowSniff.php

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -11,8 +11,20 @@ parameters:
     paths:
         - src
 
+    ignoreErrors:
+        # TODO: Cleanup needed
+        - identifier: offsetAccess.nonOffsetAccessible
+        - identifier: return.unusedType
+          paths:
+            - src/BrandEmbassyCodingStandard/Rector/MabeEnumClassToEnumRector/MabeEnumClassToEnumRector.php
+            - src/BrandEmbassyCodingStandard/Rector/NetteStringsStartsWithToNativeCallRector/NetteStringsStartsWithToNativeCallRector.php
+            - src/BrandEmbassyCodingStandard/Rector/NetteStringsEndsWithToNativeCallRector/NetteStringsEndsWithToNativeCallRector.php
+            - src/BrandEmbassyCodingStandard/Rector/MabeEnumMethodCallToEnumConstRector/MabeEnumMethodCallToEnumConstRector.php
+            - src/BrandEmbassyCodingStandard/Rector/MabeEnumClassToEnumRector/MabeEnumClassToEnumRectorTest.php
+            - src/BrandEmbassyCodingStandard/Rector/NetteStringsContainsToNativeCallRector/NetteStringsContainsToNativeCallRectorTest.php
+            - src/BrandEmbassyCodingStandard/Rector/MabeEnumMethodCallToEnumConstRector/MabeEnumMethodCallToEnumConstRectorTest.php
+
     excludePaths:
-        - src/BrandEmbassyCodingStandard/Sniffs/TypeHints/TypeHintDeclarationSniff.php
         - src/BrandEmbassyCodingStandard/*/__fixtures__/*
         - src/BrandEmbassyCodingStandard/*/__fixtures/*
 

--- a/rector.php
+++ b/rector.php
@@ -14,6 +14,8 @@ $defaultSkipList = $defaultRectorConfigurationSetup($rectorConfigBuilder);
 
 $skipList = array_merge($defaultSkipList, [
     __DIR__ . "/**/__fixtures__/**",
+    // Looks like rector bug, try removing later
+    __DIR__ . "/src/BrandEmbassyCodingStandard/Sniffs/__fixtures/codeWithElseStatement.php",
     UseClassKeywordForClassNameResolutionRector::class,
     StringClassNameToClassConstantRector::class,
 ]);

--- a/src/BrandEmbassyCodingStandard/PhpStan/Rules/Mockery/PostConditionsTraitUsedRule.php
+++ b/src/BrandEmbassyCodingStandard/PhpStan/Rules/Mockery/PostConditionsTraitUsedRule.php
@@ -10,7 +10,6 @@ use PHPStan\Rules\IdentifierRuleError;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
 use PHPStan\Rules\RuleLevelHelper;
-use PHPStan\Type\ObjectType;
 use PHPStan\Type\Type;
 use function in_array;
 use function sprintf;
@@ -82,7 +81,7 @@ class PostConditionsTraitUsedRule implements Rule
 
         $type = $typeResult->getType();
 
-        if (!$type instanceof ObjectType || $type->getClassName() !== 'Mockery\\Expectation') {
+        if (in_array('Mockery\\Expectation', $type->getObjectClassNames(), true)) {
             return [];
         }
 

--- a/src/BrandEmbassyCodingStandard/Rector/MabeEnumMethodCallToEnumConstRector/ClassNameProvider.php
+++ b/src/BrandEmbassyCodingStandard/Rector/MabeEnumMethodCallToEnumConstRector/ClassNameProvider.php
@@ -4,7 +4,6 @@ namespace BrandEmbassyCodingStandard\Rector\MabeEnumMethodCallToEnumConstRector;
 
 use PhpParser\Node;
 use PhpParser\Node\Name;
-use PHPStan\Type\TypeWithClassName;
 use Rector\NodeNameResolver\NodeNameResolver;
 use Rector\NodeTypeResolver\NodeTypeResolver;
 
@@ -27,12 +26,13 @@ class ClassNameProvider
     {
         $type = $this->nodeTypeResolver->getType($node);
 
-        if (!$type instanceof TypeWithClassName) {
+        $typeClassNames = $type->getObjectClassNames();
+        if ($typeClassNames === []) {
             return null;
         }
 
         /** @var class-string $className */
-        $className = $type->getClassName();
+        $className = $typeClassNames[0];
 
         return $className;
     }


### PR DESCRIPTION
Some phpstan baselines were added but these can be worked on later, no need to block 2.x upgrade with them. I would release this as 14.0 tag.