### PR TITLE
PHPUnit: Split tests into separate suites

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,10 +82,6 @@ $rectorConfigBuilder
 return $rectorConfigBuilder;
 ```
 
-⚠️ Tests for Rector rules need to run in a separate process, because Rector and PHPStan use different versions of php-parser.
-See explanation here https://github.com/staabm/zf-select-strip/pull/8.
-Another way would be to run them in a separate testsuite, but then we run into problems with code-coverage.
-
 PhpStorm
 --------
 This project contains inspections and code style configurations for PhpStorm.

--- a/composer.json
+++ b/composer.json
@@ -44,19 +44,31 @@
         "webmozart/assert": "^1.11"
     },
     "require-dev": {
+        "marc-mabe/php-enum": "^v3.2.0",
         "mockery/mockery": "^1.5",
+        "nette/utils": "^v4.0.5",
+        "phpunit/phpcov": "^9.0",
         "phpunit/phpunit": "^10.5",
         "roave/security-advisories": "dev-latest",
-        "nette/utils": "^v4.0.5",
-        "marc-mabe/php-enum": "^v3.2.0"
+        "sweetchuck/junit-merger-cli": "^1.0"
     },
     "scripts": {
         "check-cs": "vendor/bin/ecs check --ansi",
         "fix-cs": "vendor/bin/ecs check --fix --ansi",
         "phpstan": "php -dxdebug.mode=off vendor/bin/phpstan analyse --memory-limit=-1",
         "phpstan-generate-baseline": "php -dxdebug.mode=off vendor/bin/phpstan analyse --memory-limit=-1 --generate-baseline",
-        "phpunit": "./vendor/bin/phpunit --no-coverage",
-        "phpunit-cc": "php -dxdebug.mode=coverage ./vendor/bin/phpunit --coverage-clover=coverage.xml --log-junit=test-report.xml",
+        "phpunit": [
+            "vendor/bin/phpunit --testsuite rector --no-coverage",
+            "vendor/bin/phpunit --testsuite phpstan --no-coverage",
+            "vendor/bin/phpunit --testsuite sniffs --no-coverage"
+        ],
+        "phpunit-cc": [
+            "php -dxdebug.mode=coverage vendor/bin/phpunit --testsuite rector --coverage-php=coverage/coverage-rector.cov --log-junit=test-report-rector.xml",
+            "php -dxdebug.mode=coverage vendor/bin/phpunit --testsuite phpstan --coverage-php=coverage/coverage-phpstan.cov --log-junit=test-report-phpstan.xml",
+            "php -dxdebug.mode=coverage vendor/bin/phpunit --testsuite sniffs --coverage-php=coverage/coverage-sniffs.cov --log-junit=test-report-sniffs.xml",
+            "vendor/bin/junit-merger merge:files --output-file=test-report.xml test-report-rector.xml test-report-phpstan.xml test-report-sniffs.xml",
+            "vendor/bin/phpcov merge --clover coverage.xml coverage"
+        ],
         "check-rector": "vendor/bin/rector process --dry-run --ansi",
         "fix-rector": "vendor/bin/rector process --ansi"
     },

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -11,9 +11,16 @@
          failOnRisky="true"
          failOnWarning="true">
     <testsuites>
-        <testsuite name="default">
-            <directory>src</directory>
+        <!-- PHPStan and Rector both include their own version of PHP parser so they need to be run separately, else include conflicts arise  -->
+        <testsuite name="phpstan">
+            <directory>src/BrandEmbassyCodingStandard/PhpStan</directory>
             <exclude>src/BrandEmbassyCodingStandard/PhpStan/Rules/Method/__fixtures__/NonPhpUnitTest.php</exclude>
+        </testsuite>
+        <testsuite name="rector">
+            <directory>src/BrandEmbassyCodingStandard/Rector</directory>
+        </testsuite>
+        <testsuite name="sniffs">
+            <directory>src/BrandEmbassyCodingStandard/Sniffs</directory>
         </testsuite>
     </testsuites>
     <coverage>

--- a/src/BrandEmbassyCodingStandard/Rector/DisallowConstantsInTestsRector/DisallowConstantsInTestsRectorTest.php
+++ b/src/BrandEmbassyCodingStandard/Rector/DisallowConstantsInTestsRector/DisallowConstantsInTestsRectorTest.php
@@ -4,13 +4,11 @@ namespace BrandEmbassyCodingStandard\Rector\DisallowConstantsInTestsRector;
 
 use Iterator;
 use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 use Rector\Testing\PHPUnit\AbstractRectorTestCase;
 
 class DisallowConstantsInTestsRectorTest extends AbstractRectorTestCase
 {
     #[DataProvider('provideData')]
-    #[RunInSeparateProcess] // see README (Rector section) for why this is necessary
     public function test(string $filePath): void
     {
         $this->doTestFile($filePath);

--- a/src/BrandEmbassyCodingStandard/Rector/MabeEnumClassToEnumRector/MabeEnumClassToEnumRectorTest.php
+++ b/src/BrandEmbassyCodingStandard/Rector/MabeEnumClassToEnumRector/MabeEnumClassToEnumRectorTest.php
@@ -4,7 +4,6 @@ namespace BrandEmbassyCodingStandard\Rector\MabeEnumClassToEnumRector;
 
 use Iterator;
 use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 use Rector\Testing\PHPUnit\AbstractRectorTestCase;
 use Rector\ValueObject\PhpVersionFeature;
 use Rector\VersionBonding\Contract\MinPhpVersionInterface;
@@ -15,7 +14,6 @@ use Rector\VersionBonding\Contract\MinPhpVersionInterface;
 class MabeEnumClassToEnumRectorTest extends AbstractRectorTestCase implements MinPhpVersionInterface
 {
     #[DataProvider('provideData')]
-    #[RunInSeparateProcess] // see README (Rector section) for why this is necessary
     public function test(string $filePath): void
     {
         $this->doTestFile($filePath);

--- a/src/BrandEmbassyCodingStandard/Rector/MabeEnumMethodCallToEnumConstRector/MabeEnumMethodCallToEnumConstRectorTest.php
+++ b/src/BrandEmbassyCodingStandard/Rector/MabeEnumMethodCallToEnumConstRector/MabeEnumMethodCallToEnumConstRectorTest.php
@@ -4,7 +4,6 @@ namespace BrandEmbassyCodingStandard\Rector\MabeEnumMethodCallToEnumConstRector;
 
 use Iterator;
 use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 use Rector\Testing\PHPUnit\AbstractRectorTestCase;
 use Rector\ValueObject\PhpVersionFeature;
 use Rector\VersionBonding\Contract\MinPhpVersionInterface;
@@ -15,7 +14,6 @@ use Rector\VersionBonding\Contract\MinPhpVersionInterface;
 class MabeEnumMethodCallToEnumConstRectorTest extends AbstractRectorTestCase implements MinPhpVersionInterface
 {
     #[DataProvider('provideData')]
-    #[RunInSeparateProcess] // see README (Rector section) for why this is necessary
     public function test(string $filePath): void
     {
         $this->doTestFile($filePath);

--- a/src/BrandEmbassyCodingStandard/Rector/NetteStringsContainsToNativeCallRector/NetteStringsContainsToNativeCallRectorTest.php
+++ b/src/BrandEmbassyCodingStandard/Rector/NetteStringsContainsToNativeCallRector/NetteStringsContainsToNativeCallRectorTest.php
@@ -4,7 +4,6 @@ namespace BrandEmbassyCodingStandard\Rector\NetteStringsContainsToNativeCallRect
 
 use Iterator;
 use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 use Rector\Testing\PHPUnit\AbstractRectorTestCase;
 use Rector\ValueObject\PhpVersionFeature;
 use Rector\VersionBonding\Contract\MinPhpVersionInterface;
@@ -15,7 +14,6 @@ use Rector\VersionBonding\Contract\MinPhpVersionInterface;
 class NetteStringsContainsToNativeCallRectorTest extends AbstractRectorTestCase implements MinPhpVersionInterface
 {
     #[DataProvider('provideData')]
-    #[RunInSeparateProcess] // see README (Rector section) for why this is necessary
     public function test(string $filePath): void
     {
         $this->doTestFile($filePath);

--- a/src/BrandEmbassyCodingStandard/Rector/NetteStringsEndsWithToNativeCallRector/NetteStringsEndsWithToNativeCallRectorTest.php
+++ b/src/BrandEmbassyCodingStandard/Rector/NetteStringsEndsWithToNativeCallRector/NetteStringsEndsWithToNativeCallRectorTest.php
@@ -4,7 +4,6 @@ namespace BrandEmbassyCodingStandard\Rector\NetteStringsEndsWithToNativeCallRect
 
 use Iterator;
 use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 use Rector\Testing\PHPUnit\AbstractRectorTestCase;
 
 /**
@@ -13,7 +12,6 @@ use Rector\Testing\PHPUnit\AbstractRectorTestCase;
 class NetteStringsEndsWithToNativeCallRectorTest extends AbstractRectorTestCase
 {
     #[DataProvider('provideData')]
-    #[RunInSeparateProcess] // see README (Rector section) for why this is necessary
     public function test(string $filePath): void
     {
         $this->doTestFile($filePath);

--- a/src/BrandEmbassyCodingStandard/Rector/NetteStringsStartsWithToNativeCallRector/NetteStringsStartsWithToNativeCallRectorTest.php
+++ b/src/BrandEmbassyCodingStandard/Rector/NetteStringsStartsWithToNativeCallRector/NetteStringsStartsWithToNativeCallRectorTest.php
@@ -4,7 +4,6 @@ namespace BrandEmbassyCodingStandard\Rector\NetteStringsStartsWithToNativeCallRe
 
 use Iterator;
 use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 use Rector\Testing\PHPUnit\AbstractRectorTestCase;
 
 /**
@@ -13,7 +12,6 @@ use Rector\Testing\PHPUnit\AbstractRectorTestCase;
 class NetteStringsStartsWithToNativeCallRectorTest extends AbstractRectorTestCase
 {
     #[DataProvider('provideData')]
-    #[RunInSeparateProcess] // see README (Rector section) for why this is necessary
     public function test(string $filePath): void
     {
         $this->doTestFile($filePath);


### PR DESCRIPTION
PHPStan and Rector both include their own version of PHP parser so the tests for the rules need to be run separately, else include conflicts arise. Detailed explanation can be found here: https://github.com/staabm/zf-select-strip/pull/8

It's either this solution or keeping the `RunInSeparateProcess` attributes, which cause another set of issues.

To keep code coverage working, we need to merge the generated coverage files using external tools.