### PR TITLE
DE-138979 Create `DisallowMockeryShouldReceiveRule` to disallow using `MockInterface::shouldReceive()` in favour of `MockInterface::expects()`

### DIFF
--- a/phpstan-extension.neon
+++ b/phpstan-extension.neon
@@ -11,3 +11,7 @@ services:
         class: BrandEmbassyCodingStandard\PhpStan\Rules\Method\PhpUnitTestMethodRule
         tags:
             - phpstan.rules.rule
+    -
+        class: BrandEmbassyCodingStandard\PhpStan\Rules\Mockery\DisallowMockeryShouldReceiveRule
+        tags:
+            - phpstan.rules.rule

--- a/src/BrandEmbassyCodingStandard/PhpStan/Rules/Mockery/DisallowMockeryShouldReceiveRule.php
+++ b/src/BrandEmbassyCodingStandard/PhpStan/Rules/Mockery/DisallowMockeryShouldReceiveRule.php
@@ -1,0 +1,51 @@
+<?php declare(strict_types = 1);
+
+namespace BrandEmbassyCodingStandard\PhpStan\Rules\Mockery;
+
+use Mockery\LegacyMockInterface;
+use Mockery\MockInterface;
+use PhpParser\Node;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Identifier;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\IdentifierRuleError;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+use PHPStan\Type\ObjectType;
+
+/**
+ * @implements Rule<MethodCall>
+ */
+class DisallowMockeryShouldReceiveRule implements Rule
+{
+    public function getNodeType(): string
+    {
+        return MethodCall::class;
+    }
+
+
+    /**
+     * @param MethodCall $node
+     *
+     * @return list<IdentifierRuleError>
+     */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        if (!$node->name instanceof Identifier || $node->name->toString() !== 'shouldReceive') {
+            return [];
+        }
+
+        $calledOnType = $scope->getType($node->var);
+        $targetType = new ObjectType(LegacyMockInterface::class);
+        if (!$targetType->isSuperTypeOf($calledOnType)->yes()) {
+            return [];
+        }
+
+        return [
+            RuleErrorBuilder::message('Calling ' . MockInterface::class . '::shouldReceive() is forbidden.')
+                ->identifier('mockery.shouldReceive')
+                ->tip('Use ' . MockInterface::class . '::expects() instead, which will also assert call count.')
+                ->build(),
+        ];
+    }
+}

--- a/src/BrandEmbassyCodingStandard/PhpStan/Rules/Mockery/DisallowMockeryShouldReceiveRuleTest.php
+++ b/src/BrandEmbassyCodingStandard/PhpStan/Rules/Mockery/DisallowMockeryShouldReceiveRuleTest.php
@@ -1,0 +1,35 @@
+<?php declare(strict_types = 1);
+
+namespace BrandEmbassyCodingStandard\PhpStan\Rules\Mockery;
+
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * @extends RuleTestCase<DisallowMockeryShouldReceiveRule>
+ */
+class DisallowMockeryShouldReceiveRuleTest extends RuleTestCase
+{
+    protected function getRule(): Rule
+    {
+        return new DisallowMockeryShouldReceiveRule();
+    }
+
+
+    public function testRuleWithShouldReceive(): void
+    {
+        $this->analyse([__DIR__ . '/__fixtures__/TestCaseWithShouldReceiveExpectation.php'], [
+            [
+                'Calling Mockery\MockInterface::shouldReceive() is forbidden.',
+                13,
+                'Use Mockery\MockInterface::expects() instead, which will also assert call count.',
+            ],
+        ]);
+    }
+
+
+    public function testRuleWithExpects(): void
+    {
+        $this->analyse([__DIR__ . '/__fixtures__/TestCaseWithExpectsExpectation.php'], []);
+    }
+}

--- a/src/BrandEmbassyCodingStandard/PhpStan/Rules/Mockery/__fixtures__/SomeClass.php
+++ b/src/BrandEmbassyCodingStandard/PhpStan/Rules/Mockery/__fixtures__/SomeClass.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types = 1);
+
+namespace BrandEmbassyCodingStandard\PhpStan\Rules\Mockery\__fixtures__;
+
+class SomeClass
+{
+    public function returnOne(): int
+    {
+        return 1;
+    }
+}

--- a/src/BrandEmbassyCodingStandard/PhpStan/Rules/Mockery/__fixtures__/TestCaseWithExpectsExpectation.php
+++ b/src/BrandEmbassyCodingStandard/PhpStan/Rules/Mockery/__fixtures__/TestCaseWithExpectsExpectation.php
@@ -1,0 +1,16 @@
+<?php declare(strict_types = 1);
+
+namespace BrandEmbassyCodingStandard\PhpStan\Rules\Mockery\__fixtures__;
+
+use Mockery;
+use PHPUnit\Framework\TestCase;
+
+class TestCaseWithExpectsExpectation extends TestCase
+{
+    public function testSomething(): void
+    {
+        $mock = Mockery::mock(SomeClass::class);
+        $mock->expects('returnOne')
+            ->andReturn(1);
+    }
+}

--- a/src/BrandEmbassyCodingStandard/PhpStan/Rules/Mockery/__fixtures__/TestCaseWithShouldReceiveExpectation.php
+++ b/src/BrandEmbassyCodingStandard/PhpStan/Rules/Mockery/__fixtures__/TestCaseWithShouldReceiveExpectation.php
@@ -1,0 +1,16 @@
+<?php declare(strict_types = 1);
+
+namespace BrandEmbassyCodingStandard\PhpStan\Rules\Mockery\__fixtures__;
+
+use Mockery;
+use PHPUnit\Framework\TestCase;
+
+class TestCaseWithShouldReceiveExpectation extends TestCase
+{
+    public function testSomething(): void
+    {
+        $mock = Mockery::mock(SomeClass::class);
+        $mock->shouldReceive('returnOne')
+            ->andReturn(1);
+    }
+}


### PR DESCRIPTION
Create `DisallowMockeryShouldReceiveRule` to disallow using `MockInterface::shouldReceive()` in favour of `MockInterface::expects()`. `shouldReceive` doesn't enforce call count assertions, so then we find out we have tests like these in the codebase https://github.com/BrandEmbassy/channel-integrations/commit/b200ce77d07363c90ea83a67eeabab4796072cca. The expectations apply to only one of four test cases, but they were in setup because call count wasn't set up and everything was passing -> confusing.

We've agreed on this a long time ago here https://github.com/BrandEmbassy/developers-manifest/issues/631 but noone implemented the rule yet. This rule is just to forbid new occurrences. Next step could be to implement a Rector rule that transforms current usage.

