### PR TITLE
DE-138733 Add `pb30/phpstan-composer-analysis` to protect against shadow (transitive) dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
         "phpstan/phpstan-nette": "^2.0",
         "phpstan/phpstan-phpunit": "^2.0",
         "phpstan/phpstan-strict-rules": "^2.0",
-        "rector/rector": "^2.0",
+        "rector/rector": "^2.1",
         "slevomat/coding-standard": "^8.15.0",
         "squizlabs/php_codesniffer": "^3.9.2",
         "symplify/easy-coding-standard": "^12.1.14",

--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,7 @@
         "php": ">=8.1",
         "composer-runtime-api": "^2.2",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.5 || ^0.7 || ^1.0",
+        "pb30/phpstan-composer-analysis": "^1.0",
         "phpstan/phpstan": "^2.0",
         "phpstan/phpstan-mockery": "^2.0",
         "phpstan/phpstan-nette": "^2.0",

--- a/default-phpstan.neon
+++ b/default-phpstan.neon
@@ -5,6 +5,7 @@ includes:
     - ../../../vendor/phpstan/phpstan-phpunit/extension.neon
     - ../../../vendor/brandembassy/coding-standard/phpstan-extension.neon
     - ../../../vendor/tomasvotruba/cognitive-complexity/config/extension.neon
+    - ../../../vendor/pb30/phpstan-composer-analysis/extension.neon
 
 services:
     # Handy services from Rector package


### PR DESCRIPTION
The extension is added to the `default-phpstan.neon` because it's something we want to distribute to all of our repositories. It may show a lot of new errors but the fix is really easy -> add the dependencies to composer.json `require` as they should be.

You can also configure the extension to your needs like this: https://github.com/pb30/phpstan-composer-analysis?tab=readme-ov-file#configuration

Tested on platform-backend and it doesn't extend the phpstan run time (cache was deleted before each run).

Without extension:
<img width="979" height="367" alt="image" src="https://github.com/user-attachments/assets/405f8dc7-2812-4b61-9c79-0d06b18128eb" />
With extension:
<img width="615" height="353" alt="image" src="https://github.com/user-attachments/assets/df83d023-6fc5-4256-bdcf-910bf4e04d74" />

Output looks like this:
<img width="1550" height="1060" alt="image" src="https://github.com/user-attachments/assets/ac08b9a2-b633-476c-85ce-5e5ab9bf7d54" />

Also Bump rector/rector from ^2.0 to ^2.1. There seems to be a bug in the lower version that prevents us from testing the Rector rules with `composer update --prefer-lowest`.
