### PR TITLE
DE-160171 Update PHP constraint for PHP 8.4 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "dg/bypass-finals": "*"
     },
     "require": {
-        "php": ">=8.1",
+        "php": "~8.2 || ~8.4",
         "composer-runtime-api": "^2.2",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.5 || ^0.7 || ^1.0",
         "pb30/phpstan-composer-analysis": "^1.0",


### PR DESCRIPTION
Description: Update PHP version constraint to ~8.2 || ~8.4 for PHP 8.4 compatibility
Possible impact: PHP version constraint only, no code changes

---
## Summary
- Update PHP version constraint to `~8.2 || ~8.4`
- Full codebase scan found zero PHP 8.4 breaking changes
- No code modifications needed

## Test Plan
- [x] Scanned for implicit nullable params (BC-001) - none found
- [x] Scanned for get_class() without args (BC-002) - none found
- [x] Scanned for other PHP 8.4 deprecations - none found
- [ ] CI passes on PHP 8.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)