### PR TITLE
Add ArrayFormattingSniff ECS rule for array formatting

### DIFF
--- a/default-ecs.php
+++ b/default-ecs.php
@@ -1,5 +1,6 @@
 <?php declare(strict_types = 1);
 
+use BrandEmbassyCodingStandard\Sniffs\Arrays\ArrayFormatting\ArrayFormattingSniff;
 use BrandEmbassyCodingStandard\Sniffs\Classes\ClassesWithoutSelfReferencingSniff;
 use BrandEmbassyCodingStandard\Sniffs\Classes\FinalClassByAnnotationSniff;
 use BrandEmbassyCodingStandard\Sniffs\Classes\TraitUsePositionSniff;
@@ -239,9 +240,7 @@ return static function (ECSConfig $ecsConfig, string $projectRootPath): array {
     // ]);
 
     // region SetList::CLEAN_CODE
-    $ecsConfig->ruleWithConfiguration(ArraySyntaxFixer::class, [
-        'syntax' => 'short',
-    ]);
+    $ecsConfig->ruleWithConfiguration(ArraySyntaxFixer::class, ['syntax' => 'short']);
     $ecsConfig->rules(
         [
             ParamReturnAndVarTagMalformsFixer::class,
@@ -279,7 +278,14 @@ return static function (ECSConfig $ecsConfig, string $projectRootPath): array {
     $ecsConfig->ruleWithConfiguration(
         GeneralPhpdocAnnotationRemoveFixer::class,
         [
-            'annotations' => ['throws', 'author', 'package', 'group', 'covers', 'category'],
+            'annotations' => [
+                'throws',
+                'author',
+                'package',
+                'group',
+                'covers',
+                'category',
+            ],
         ],
     );
     // endregion SetList::SYMPLIFY
@@ -300,7 +306,12 @@ return static function (ECSConfig $ecsConfig, string $projectRootPath): array {
     $ecsConfig->ruleWithConfiguration(
         NoTrailingCommaInSinglelineFixer::class,
         [
-            'elements' => ['arguments', 'array_destructuring', 'array', 'group_import'],
+            'elements' => [
+                'arguments',
+                'array_destructuring',
+                'array',
+                'group_import',
+            ],
         ],
     );
     $ecsConfig->ruleWithConfiguration(
@@ -309,9 +320,7 @@ return static function (ECSConfig $ecsConfig, string $projectRootPath): array {
             'elements' => [TrailingCommaInMultilineFixer::ELEMENTS_ARRAYS],
         ],
     );
-    $ecsConfig->ruleWithConfiguration(ArraySyntaxFixer::class, [
-        'syntax' => 'short',
-    ]);
+    $ecsConfig->ruleWithConfiguration(ArraySyntaxFixer::class, ['syntax' => 'short']);
     // endregion SetList::COMMON - vendor/symplify/easy-coding-standard/config/set/common/array.php
 
     // region SetList::COMMON - vendor/symplify/easy-coding-standard/config/set/common/comments.php
@@ -338,12 +347,13 @@ return static function (ECSConfig $ecsConfig, string $projectRootPath): array {
     $ecsConfig->ruleWithConfiguration(
         SingleClassElementPerStatementFixer::class,
         [
-            'elements' => ['const', 'property'],
+            'elements' => [
+                'const',
+                'property',
+            ],
         ],
     );
-    $ecsConfig->ruleWithConfiguration(ClassDefinitionFixer::class, [
-        'single_line' => true,
-    ]);
+    $ecsConfig->ruleWithConfiguration(ClassDefinitionFixer::class, ['single_line' => true]);
     $ecsConfig->ruleWithConfiguration(
         YodaStyleFixer::class,
         [
@@ -388,7 +398,10 @@ return static function (ECSConfig $ecsConfig, string $projectRootPath): array {
     // endregion SetList::COMMON - vendor/symplify/easy-coding-standard/config/set/common/phpunit.php
 
     // region SetList::COMMON - vendor/symplify/easy-coding-standard/config/set/common/namespaces.php
-    $ecsConfig->rules([PhpUnitTestAnnotationFixer::class, PhpUnitSetUpTearDownVisibilityFixer::class]);
+    $ecsConfig->rules([
+        PhpUnitTestAnnotationFixer::class,
+        PhpUnitSetUpTearDownVisibilityFixer::class,
+    ]);
     // endregion SetList::COMMON - vendor/symplify/easy-coding-standard/config/set/common/namespaces.php
 
     // region SetList::COMMON - vendor/symplify/easy-coding-standard/config/set/common/spaces.php
@@ -425,12 +438,8 @@ return static function (ECSConfig $ecsConfig, string $projectRootPath): array {
             ],
         ],
     );
-    $ecsConfig->ruleWithConfiguration(ConcatSpaceFixer::class, [
-        'spacing' => 'one',
-    ]);
-    $ecsConfig->ruleWithConfiguration(SuperfluousWhitespaceSniff::class, [
-        'ignoreBlankLines' => false,
-    ]);
+    $ecsConfig->ruleWithConfiguration(ConcatSpaceFixer::class, ['spacing' => 'one']);
+    $ecsConfig->ruleWithConfiguration(SuperfluousWhitespaceSniff::class, ['ignoreBlankLines' => false]);
     $ecsConfig->ruleWithConfiguration(
         BinaryOperatorSpacesFixer::class,
         [
@@ -453,11 +462,13 @@ return static function (ECSConfig $ecsConfig, string $projectRootPath): array {
 
     // region SetList::PSR_12 - vendor/symplify/easy-coding-standard/config/set/psr12.php
     $ecsConfig->ruleWithConfiguration(OrderedImportsFixer::class, [
-        'imports_order' => ['class', 'function', 'const'],
+        'imports_order' => [
+            'class',
+            'function',
+            'const',
+        ],
     ]);
-    $ecsConfig->ruleWithConfiguration(DeclareEqualNormalizeFixer::class, [
-        'space' => 'none',
-    ]);
+    $ecsConfig->ruleWithConfiguration(DeclareEqualNormalizeFixer::class, ['space' => 'none']);
     $ecsConfig->ruleWithConfiguration(
         BracesFixer::class,
         [
@@ -480,7 +491,11 @@ return static function (ECSConfig $ecsConfig, string $projectRootPath): array {
         ],
     );
     $ecsConfig->ruleWithConfiguration(VisibilityRequiredFixer::class, [
-        'elements' => ['const', 'method', 'property'],
+        'elements' => [
+            'const',
+            'method',
+            'property',
+        ],
     ]);
     $ecsConfig->rules([
         BinaryOperatorSpacesFixer::class,
@@ -519,22 +534,16 @@ return static function (ECSConfig $ecsConfig, string $projectRootPath): array {
         VisibilityRequiredFixer::class,
         WhitespaceAfterCommaInArrayFixer::class,
     ]);
-    $ecsConfig->ruleWithConfiguration(MethodArgumentSpaceFixer::class, [
-        'on_multiline' => 'ensure_fully_multiline',
-    ]);
+    $ecsConfig->ruleWithConfiguration(MethodArgumentSpaceFixer::class, ['on_multiline' => 'ensure_fully_multiline']);
     $ecsConfig->ruleWithConfiguration(SingleClassElementPerStatementFixer::class, [
         'elements' => ['property'],
     ]);
-    $ecsConfig->ruleWithConfiguration(ConcatSpaceFixer::class, [
-        'spacing' => 'one',
-    ]);
+    $ecsConfig->ruleWithConfiguration(ConcatSpaceFixer::class, ['spacing' => 'one']);
     $ecsConfig->skip([SingleImportPerStatementFixer::class]);
     // endregion SetList::PSR_12 - vendor/symplify/easy-coding-standard/config/set/psr12.php
 
     // region SetList::DOCTRINE_ANNOTATIONS - vendor/symplify/easy-coding-standard/config/set/doctrine-annotations.php
-    $ecsConfig->ruleWithConfiguration(DoctrineAnnotationIndentationFixer::class, [
-        'indent_mixed_lines' => true,
-    ]);
+    $ecsConfig->ruleWithConfiguration(DoctrineAnnotationIndentationFixer::class, ['indent_mixed_lines' => true]);
     $ecsConfig->ruleWithConfiguration(
         DoctrineAnnotationSpacesFixer::class,
         [
@@ -547,9 +556,7 @@ return static function (ECSConfig $ecsConfig, string $projectRootPath): array {
 
     // region === brand embassy coding standard ===
     $ecsConfig->rule(LineLengthFixer::class);
-    $ecsConfig->ruleWithConfiguration(PhpdocLineSpanFixer::class, [
-        'const' => 'single',
-    ]);
+    $ecsConfig->ruleWithConfiguration(PhpdocLineSpanFixer::class, ['const' => 'single']);
     // Forbid duplicate classes
     $ecsConfig->rule(DuplicateClassNameSniff::class);
     // Forbid `array(...)`
@@ -628,9 +635,7 @@ return static function (ECSConfig $ecsConfig, string $projectRootPath): array {
         'allowMultiline' => true,
     ]);
     // Forbid useless inline string concatenation
-    $ecsConfig->ruleWithConfiguration(ArbitraryParenthesesSpacingSniff::class, [
-        'ignoreNewlines' => true,
-    ]);
+    $ecsConfig->ruleWithConfiguration(ArbitraryParenthesesSpacingSniff::class, ['ignoreNewlines' => true]);
     // Forbid tabs for indentation
     $ecsConfig->rule(DisallowTabIndentSniff::class);
     // Require space after language constructs
@@ -685,9 +690,7 @@ return static function (ECSConfig $ecsConfig, string $projectRootPath): array {
     // Requires use of null coalesce operator when possible
     $ecsConfig->rule(RequireNullCoalesceOperatorSniff::class);
     // Forbid unused use statements
-    $ecsConfig->ruleWithConfiguration(UnusedUsesSniff::class, [
-        'searchAnnotations' => true,
-    ]);
+    $ecsConfig->ruleWithConfiguration(UnusedUsesSniff::class, ['searchAnnotations' => true]);
     // Forbid useless uses of the same namespace
     $ecsConfig->rule(UseFromSameNamespaceSniff::class);
     // Forbid useless unreachable catch blocks
@@ -773,9 +776,7 @@ return static function (ECSConfig $ecsConfig, string $projectRootPath): array {
     // Prohibits multiple traits separated by commas in one use statement
     $ecsConfig->rule(TraitUseDeclarationSniff::class);
     // Looks for unused variables
-    $ecsConfig->ruleWithConfiguration(UnusedVariableSniff::class, [
-        'ignoreUnusedValuesWhenOnlyKeysAreUsedInForeach' => true,
-    ]);
+    $ecsConfig->ruleWithConfiguration(UnusedVariableSniff::class, ['ignoreUnusedValuesWhenOnlyKeysAreUsedInForeach' => true]);
     // Looks for useless parameter default value
     $ecsConfig->rule(UnusedInheritedVariablePassedToClosureSniff::class);
     // Looks for use alias that is same as unqualified name
@@ -785,9 +786,7 @@ return static function (ECSConfig $ecsConfig, string $projectRootPath): array {
     // Requires arrow functions for one-line Closures
     $ecsConfig->rule(RequireArrowFunctionSniff::class);
     // Arrow function formatting
-    $ecsConfig->ruleWithConfiguration(ArrowFunctionDeclarationSniff::class, [
-        'spacesCountAfterKeyword' => 0,
-    ]);
+    $ecsConfig->ruleWithConfiguration(ArrowFunctionDeclarationSniff::class, ['spacesCountAfterKeyword' => 0]);
     // Requires trailing comma in multiline function calls
     $ecsConfig->rule(RequireTrailingCommaInCallSniff::class);
     // Disallows implicit array creation
@@ -812,6 +811,8 @@ return static function (ECSConfig $ecsConfig, string $projectRootPath): array {
     $ecsConfig->rule(CamelCapsFunctionNameSniff::class);
     // Forbid spacing after and before array brackets
     $ecsConfig->rule(ArrayBracketSpacingSniff::class);
+    // Force single-element arrays inline and multi-element arrays multiline
+    $ecsConfig->rule(ArrayFormattingSniff::class);
     // Force array declaration structure
     $ecsConfig->rule(ArrayDeclarationSniff::class);
     // Forbid class being in a file with different name
@@ -831,9 +832,7 @@ return static function (ECSConfig $ecsConfig, string $projectRootPath): array {
     // Force rules for variable comments
     $ecsConfig->rule(VariableCommentSniff::class);
     // Force rules for function argument spacing
-    $ecsConfig->ruleWithConfiguration(FunctionDeclarationArgumentSpacingSniff::class, [
-        'equalsSpacing' => 1,
-    ]);
+    $ecsConfig->ruleWithConfiguration(FunctionDeclarationArgumentSpacingSniff::class, ['equalsSpacing' => 1]);
     // Forbid global functions
     $ecsConfig->rule(GlobalFunctionSniff::class);
     // Force function keyword to be lowercase
@@ -875,15 +874,11 @@ return static function (ECSConfig $ecsConfig, string $projectRootPath): array {
         'spacingBeforeFirst' => 0,
     ]);
     // Forbid spaces around `->` operator
-    $ecsConfig->ruleWithConfiguration(ObjectOperatorSpacingSniff::class, [
-        'ignoreNewlines' => true,
-    ]);
+    $ecsConfig->ruleWithConfiguration(ObjectOperatorSpacingSniff::class, ['ignoreNewlines' => true]);
     // Forbid spaces before semicolon `;`
     $ecsConfig->rule(SemicolonSpacingSniff::class);
     // Forbid superfluous whitespaces
-    $ecsConfig->ruleWithConfiguration(SuperfluousWhitespaceSniff::class, [
-        'ignoreBlankLines' => false,
-    ]);
+    $ecsConfig->ruleWithConfiguration(SuperfluousWhitespaceSniff::class, ['ignoreBlankLines' => false]);
     // Force trait use as first statement in class
     $ecsConfig->rule(TraitUsePositionSniff::class);
     // Require empty newlines after uses
@@ -928,15 +923,18 @@ return static function (ECSConfig $ecsConfig, string $projectRootPath): array {
         'closure_fn_spacing' => 'none',
     ]);
 
-    $ecsConfig->ruleWithConfiguration(CastSpacesFixer::class, [
-        'space' => 'none',
-    ]);
+    $ecsConfig->ruleWithConfiguration(CastSpacesFixer::class, ['space' => 'none']);
 
     // Override configuration from SetList::SYMPLIFY, we don't want to remove the @throws and @group annotations
     $ecsConfig->ruleWithConfiguration(
         GeneralPhpdocAnnotationRemoveFixer::class,
         [
-            'annotations' => ['author', 'package', 'covers', 'category'],
+            'annotations' => [
+                'author',
+                'package',
+                'covers',
+                'category',
+            ],
         ],
     );
 

--- a/ecs.php
+++ b/ecs.php
@@ -19,14 +19,16 @@ return static function (ECSConfig $ecsConfig) use ($defaultEcsConfigurationSetup
 
     $skipList = [
         InlineCommentSniff::class => [__DIR__ . '/default-ecs.php'],
-        CommentedOutCodeSniff::class => [__DIR__ . '/ecs.php', __DIR__ . '/default-ecs.php'],
-        ArrayDeclarationSniff::class => [__DIR__ . '/ecs.php', __DIR__ . '/default-ecs.php'],
-        UnusedFunctionParameterSniff::class . '.FoundInImplementedInterface' => [
-            __DIR__ . '/src/BrandEmbassyCodingStandard/PhpStan/Rules/Method/ImmutableWitherMethodRule.php',
+        CommentedOutCodeSniff::class => [
+            __DIR__ . '/ecs.php',
+            __DIR__ . '/default-ecs.php',
         ],
-        UnusedFunctionParameterSniff::class . '.FoundInImplementedInterfaceAfterLastUsed' => [
-            __DIR__ . '/src/BrandEmbassyCodingStandard/PhpStan/Rules/Method/ImmutableWitherMethodRule.php',
+        ArrayDeclarationSniff::class => [
+            __DIR__ . '/ecs.php',
+            __DIR__ . '/default-ecs.php',
         ],
+        UnusedFunctionParameterSniff::class . '.FoundInImplementedInterface' => [__DIR__ . '/src/BrandEmbassyCodingStandard/PhpStan/Rules/Method/ImmutableWitherMethodRule.php'],
+        UnusedFunctionParameterSniff::class . '.FoundInImplementedInterfaceAfterLastUsed' => [__DIR__ . '/src/BrandEmbassyCodingStandard/PhpStan/Rules/Method/ImmutableWitherMethodRule.php'],
         'SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint' => [
             __DIR__ . '/src/BrandEmbassyCodingStandard/Sniffs/Classes/ClassesWithoutSelfReferencingSniff.php',
             __DIR__ . '/src/BrandEmbassyCodingStandard/Sniffs/Classes/FinalClassByAnnotationSniff.php',

--- a/src/BrandEmbassyCodingStandard/Rector/DisallowConstantsInTestsRector/DisallowConstantsInTestsRector.php
+++ b/src/BrandEmbassyCodingStandard/Rector/DisallowConstantsInTestsRector/DisallowConstantsInTestsRector.php
@@ -72,7 +72,11 @@ final class Foo
 CODE_SAMPLE
                     ,
                     [
-                        self::ALLOWED_PATTERNS => ['vendor/*', 'tests/*', '*Fixture.php'],
+                        self::ALLOWED_PATTERNS => [
+                            'vendor/*',
+                            'tests/*',
+                            '*Fixture.php',
+                        ],
                         self::ALLOWED_CONSTANTS => ['Project\Http\HttpMethod'],
                     ],
                 ),

--- a/src/BrandEmbassyCodingStandard/Rector/MabeEnumMethodCallToEnumConstRector/MabeEnumMethodCallToEnumConstRector.php
+++ b/src/BrandEmbassyCodingStandard/Rector/MabeEnumMethodCallToEnumConstRector/MabeEnumMethodCallToEnumConstRector.php
@@ -69,9 +69,7 @@ class MabeEnumMethodCallToEnumConstRector extends AbstractRector implements MinP
             new ConfiguredCodeSample(
                 'IgnoredEnum::getValue()',
                 'IgnoredEnum::getValue()',
-                [
-                    self::ARE_CLASSES_FROM_VENDOR_IGNORED => false,
-                ],
+                [self::ARE_CLASSES_FROM_VENDOR_IGNORED => false],
             ),
         ]);
     }

--- a/src/BrandEmbassyCodingStandard/Rector/MabeEnumMethodCallToEnumConstRector/config/configured_rule.php
+++ b/src/BrandEmbassyCodingStandard/Rector/MabeEnumMethodCallToEnumConstRector/config/configured_rule.php
@@ -4,7 +4,5 @@ use BrandEmbassyCodingStandard\Rector\MabeEnumMethodCallToEnumConstRector\MabeEn
 use Rector\Config\RectorConfig;
 
 return static function (RectorConfig $rectorConfig): void {
-    $rectorConfig->ruleWithConfiguration(MabeEnumMethodCallToEnumConstRector::class, [
-        MabeEnumMethodCallToEnumConstRector::ARE_CLASSES_FROM_VENDOR_IGNORED => true,
-    ]);
+    $rectorConfig->ruleWithConfiguration(MabeEnumMethodCallToEnumConstRector::class, [MabeEnumMethodCallToEnumConstRector::ARE_CLASSES_FROM_VENDOR_IGNORED => true]);
 };

--- a/src/BrandEmbassyCodingStandard/Sniffs/Arrays/ArrayFormatting/ArrayFormattingSniff.php
+++ b/src/BrandEmbassyCodingStandard/Sniffs/Arrays/ArrayFormatting/ArrayFormattingSniff.php
@@ -1,0 +1,422 @@
+<?php declare(strict_types = 1);
+
+namespace BrandEmbassyCodingStandard\Sniffs\Arrays\ArrayFormatting;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+use function assert;
+use function is_int;
+use function is_string;
+use function str_contains;
+use function str_repeat;
+use function strlen;
+use const T_COMMA;
+use const T_OPEN_CURLY_BRACKET;
+use const T_OPEN_PARENTHESIS;
+use const T_OPEN_SHORT_ARRAY;
+use const T_WHITESPACE;
+
+class ArrayFormattingSniff implements Sniff
+{
+    public const CODE_SINGLE_ELEMENT_NOT_INLINE = 'SingleElementNotInline';
+
+    public const CODE_MULTI_ELEMENT_NOT_MULTILINE = 'MultiElementNotMultiline';
+
+    public const CODE_NESTED_NOT_MULTILINE = 'NestedNotMultiline';
+
+    private const INDENT_SIZE = 4;
+
+
+    /**
+     * @return list<int|string>
+     */
+    public function register(): array
+    {
+        return [T_OPEN_SHORT_ARRAY];
+    }
+
+
+    /**
+     * @phpcsSuppress SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint
+     *
+     * @param int $stackPtr
+     */
+    public function process(File $phpcsFile, $stackPtr): void
+    {
+        $tokens = $phpcsFile->getTokens();
+        $opener = $stackPtr;
+
+        /** @var int $closer */
+        $closer = $tokens[$opener]['bracket_closer'];
+
+        $elementCount = $this->countElements($phpcsFile, $opener, $closer);
+
+        if ($elementCount === 0) {
+            return;
+        }
+
+        $isMultiline = $tokens[$opener]['line'] !== $tokens[$closer]['line'];
+        $hasNestedArray = $this->containsNestedArray($phpcsFile, $opener, $closer);
+
+        if ($hasNestedArray && !$isMultiline) {
+            $fix = $phpcsFile->addFixableError(
+                'Array containing nested array must be multiline',
+                $opener,
+                self::CODE_NESTED_NOT_MULTILINE,
+            );
+
+            if ($fix) {
+                $this->fixToMultiline($phpcsFile, $opener, $closer);
+            }
+
+            return;
+        }
+
+        if ($elementCount === 1 && $isMultiline && !$hasNestedArray && !$this->elementContentIsMultiline($phpcsFile, $opener, $closer)) {
+            $fix = $phpcsFile->addFixableError(
+                'Single-element array must be inline',
+                $opener,
+                self::CODE_SINGLE_ELEMENT_NOT_INLINE,
+            );
+
+            if ($fix) {
+                $this->fixToInline($phpcsFile, $opener, $closer);
+            }
+        }
+
+        if ($elementCount > 1 && !$isMultiline) {
+            $fix = $phpcsFile->addFixableError(
+                'Multi-element array must have each element on its own line',
+                $opener,
+                self::CODE_MULTI_ELEMENT_NOT_MULTILINE,
+            );
+
+            if ($fix) {
+                $this->fixToMultiline($phpcsFile, $opener, $closer);
+            }
+        }
+    }
+
+
+    private function countElements(File $phpcsFile, int $opener, int $closer): int
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        if ($closer - $opener === 1) {
+            return 0;
+        }
+
+        $hasContent = false;
+
+        for ($i = $opener + 1; $i < $closer; $i++) {
+            if ($tokens[$i]['code'] !== T_WHITESPACE) {
+                $hasContent = true;
+                break;
+            }
+        }
+
+        if (!$hasContent) {
+            return 0;
+        }
+
+        $commaCount = 0;
+
+        for ($i = $opener + 1; $i < $closer; $i++) {
+            $code = $tokens[$i]['code'];
+
+            if ($code === T_OPEN_SHORT_ARRAY) {
+                /** @var int $nestedCloser */
+                $nestedCloser = $tokens[$i]['bracket_closer'];
+                $i = $nestedCloser;
+                continue;
+            }
+
+            if ($code === T_OPEN_PARENTHESIS) {
+                /** @var int $parenCloser */
+                $parenCloser = $tokens[$i]['parenthesis_closer'];
+                $i = $parenCloser;
+                continue;
+            }
+
+            if ($code === T_OPEN_CURLY_BRACKET) {
+                /** @var int $curlyCloser */
+                $curlyCloser = $tokens[$i]['bracket_closer'];
+                $i = $curlyCloser;
+                continue;
+            }
+
+            if ($code === T_COMMA) {
+                $commaCount++;
+            }
+        }
+
+        if ($this->hasTrailingComma($phpcsFile, $opener, $closer)) {
+            $commaCount--;
+        }
+
+        return $commaCount + 1;
+    }
+
+
+    private function hasTrailingComma(File $phpcsFile, int $opener, int $closer): bool
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        for ($i = $closer - 1; $i > $opener; $i--) {
+            if ($tokens[$i]['code'] === T_WHITESPACE) {
+                continue;
+            }
+
+            return $tokens[$i]['code'] === T_COMMA;
+        }
+
+        return false;
+    }
+
+
+    private function containsNestedArray(File $phpcsFile, int $opener, int $closer): bool
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        for ($i = $opener + 1; $i < $closer; $i++) {
+            if ($tokens[$i]['code'] === T_OPEN_SHORT_ARRAY) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+
+    private function elementContentIsMultiline(File $phpcsFile, int $opener, int $closer): bool
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        $firstContent = null;
+        $lastContent = null;
+
+        for ($i = $opener + 1; $i < $closer; $i++) {
+            if ($tokens[$i]['code'] !== T_WHITESPACE) {
+                if ($firstContent === null) {
+                    $firstContent = $i;
+                }
+
+                $lastContent = $i;
+            }
+        }
+
+        if ($firstContent === null || $lastContent === null) {
+            return false;
+        }
+
+        // Exclude trailing comma from the check
+        if ($tokens[$lastContent]['code'] === T_COMMA) {
+            for ($i = $lastContent - 1; $i > $opener; $i--) {
+                if ($tokens[$i]['code'] !== T_WHITESPACE) {
+                    $lastContent = $i;
+                    break;
+                }
+            }
+        }
+
+        return $tokens[$firstContent]['line'] !== $tokens[$lastContent]['line'];
+    }
+
+
+    private function fixToInline(File $phpcsFile, int $opener, int $closer): void
+    {
+        $tokens = $phpcsFile->getTokens();
+        $phpcsFile->fixer->beginChangeset();
+
+        $firstContent = null;
+        $lastContent = null;
+        $trailingCommaPos = null;
+
+        for ($i = $opener + 1; $i < $closer; $i++) {
+            if ($tokens[$i]['code'] !== T_WHITESPACE) {
+                if ($firstContent === null) {
+                    $firstContent = $i;
+                }
+
+                $lastContent = $i;
+            }
+        }
+
+        if ($this->hasTrailingComma($phpcsFile, $opener, $closer)) {
+            $trailingCommaPos = $lastContent;
+            assert(is_int($trailingCommaPos));
+            // Find the actual last content before the trailing comma
+            for ($i = $trailingCommaPos - 1; $i > $opener; $i--) {
+                if ($tokens[$i]['code'] !== T_WHITESPACE) {
+                    $lastContent = $i;
+                    break;
+                }
+            }
+        }
+
+        for ($i = $opener + 1; $i < $closer; $i++) {
+            // Remove trailing comma
+            if ($trailingCommaPos !== null && $i === $trailingCommaPos) {
+                $phpcsFile->fixer->replaceToken($i, '');
+                continue;
+            }
+
+            if ($tokens[$i]['code'] !== T_WHITESPACE) {
+                continue;
+            }
+
+            // Remove all whitespace before first content and after last content
+            if ($firstContent !== null && $lastContent !== null && ($i < $firstContent || $i > $lastContent)) {
+                $phpcsFile->fixer->replaceToken($i, '');
+                continue;
+            }
+
+            // For whitespace between content tokens, collapse newlines to space
+            $content = $tokens[$i]['content'];
+            assert(is_string($content));
+
+            if (str_contains($content, "\n")) {
+                $phpcsFile->fixer->replaceToken($i, ' ');
+            }
+        }
+
+        $phpcsFile->fixer->endChangeset();
+    }
+
+
+    private function fixToMultiline(File $phpcsFile, int $opener, int $closer): void
+    {
+        $tokens = $phpcsFile->getTokens();
+        $phpcsFile->fixer->beginChangeset();
+
+        $baseIndent = $this->getIndentLevel($phpcsFile, $opener);
+        $elementIndent = str_repeat(' ', $baseIndent + self::INDENT_SIZE);
+        $closerIndent = str_repeat(' ', $baseIndent);
+
+        $phpcsFile->fixer->addContent($opener, "\n" . $elementIndent);
+
+        $this->removeWhitespaceAfter($phpcsFile, $opener, $closer);
+
+        $lastCommaPointer = null;
+
+        for ($i = $opener + 1; $i < $closer; $i++) {
+            $code = $tokens[$i]['code'];
+
+            if ($code === T_OPEN_SHORT_ARRAY) {
+                /** @var int $nestedCloser */
+                $nestedCloser = $tokens[$i]['bracket_closer'];
+                $i = $nestedCloser;
+                continue;
+            }
+
+            if ($code === T_OPEN_PARENTHESIS) {
+                /** @var int $parenCloser */
+                $parenCloser = $tokens[$i]['parenthesis_closer'];
+                $i = $parenCloser;
+                continue;
+            }
+
+            if ($code === T_OPEN_CURLY_BRACKET) {
+                /** @var int $curlyCloser */
+                $curlyCloser = $tokens[$i]['bracket_closer'];
+                $i = $curlyCloser;
+                continue;
+            }
+
+            if ($code === T_COMMA) {
+                $lastCommaPointer = $i;
+
+                $this->removeWhitespaceAfter($phpcsFile, $i, $closer);
+
+                $phpcsFile->fixer->addContent($i, "\n" . $elementIndent);
+            }
+        }
+
+        if (!$this->hasTrailingComma($phpcsFile, $opener, $closer)) {
+            $searchFrom = $lastCommaPointer !== null
+                ? $lastCommaPointer + 1
+                : $opener + 1;
+            $lastElementEnd = $this->findLastNonWhitespace($phpcsFile, $searchFrom, $closer);
+
+            if ($lastElementEnd !== null) {
+                $phpcsFile->fixer->addContent($lastElementEnd, ',');
+            }
+        }
+
+        $this->removeWhitespaceBefore($phpcsFile, $opener, $closer);
+
+        $phpcsFile->fixer->addContentBefore($closer, "\n" . $closerIndent);
+
+        $phpcsFile->fixer->endChangeset();
+    }
+
+
+    private function getIndentLevel(File $phpcsFile, int $stackPtr): int
+    {
+        $tokens = $phpcsFile->getTokens();
+        $line = $tokens[$stackPtr]['line'];
+        $firstOnLine = $stackPtr;
+
+        for ($i = $stackPtr - 1; $i >= 0; $i--) {
+            if ($tokens[$i]['line'] !== $line) {
+                $firstOnLine = $i + 1;
+                break;
+            }
+
+            if ($i === 0) {
+                $firstOnLine = 0;
+            }
+        }
+
+        if ($tokens[$firstOnLine]['code'] === T_WHITESPACE) {
+            $content = $tokens[$firstOnLine]['content'];
+            assert(is_string($content));
+
+            return strlen($content);
+        }
+
+        return 0;
+    }
+
+
+    private function removeWhitespaceAfter(File $phpcsFile, int $position, int $closer): void
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        for ($i = $position + 1; $i < $closer; $i++) {
+            if ($tokens[$i]['code'] !== T_WHITESPACE) {
+                break;
+            }
+
+            $phpcsFile->fixer->replaceToken($i, '');
+        }
+    }
+
+
+    private function removeWhitespaceBefore(File $phpcsFile, int $opener, int $closer): void
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        for ($i = $closer - 1; $i > $opener; $i--) {
+            if ($tokens[$i]['code'] !== T_WHITESPACE) {
+                break;
+            }
+
+            $phpcsFile->fixer->replaceToken($i, '');
+        }
+    }
+
+
+    private function findLastNonWhitespace(File $phpcsFile, int $start, int $end): ?int
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        for ($i = $end - 1; $i >= $start; $i--) {
+            if ($tokens[$i]['code'] !== T_WHITESPACE) {
+                return $i;
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/BrandEmbassyCodingStandard/Sniffs/Arrays/ArrayFormatting/ArrayFormattingSniffTest.php
+++ b/src/BrandEmbassyCodingStandard/Sniffs/Arrays/ArrayFormatting/ArrayFormattingSniffTest.php
@@ -1,0 +1,84 @@
+<?php declare(strict_types = 1);
+
+namespace BrandEmbassyCodingStandard\Sniffs\Arrays\ArrayFormatting;
+
+use PHPUnit\Framework\Assert;
+use SlevomatCodingStandard\Sniffs\TestCase;
+
+/**
+ * @final
+ */
+class ArrayFormattingSniffTest extends TestCase
+{
+    public function testCorrectFormattingProducesNoErrors(): void
+    {
+        $report = self::checkFile(__DIR__ . '/__fixtures__/correctFormatting.php');
+        self::assertNoSniffErrorInFile($report);
+    }
+
+
+    public function testSingleElementMultilineArraysAreFixed(): void
+    {
+        $report = self::checkFile(__DIR__ . '/__fixtures__/singleElementMultiline.php');
+
+        Assert::assertSame(3, $report->getErrorCount());
+
+        self::assertSniffError($report, 5, ArrayFormattingSniff::CODE_SINGLE_ELEMENT_NOT_INLINE);
+        self::assertSniffError($report, 9, ArrayFormattingSniff::CODE_SINGLE_ELEMENT_NOT_INLINE);
+        self::assertSniffError($report, 13, ArrayFormattingSniff::CODE_SINGLE_ELEMENT_NOT_INLINE);
+
+        self::assertAllFixedInFile($report);
+    }
+
+
+    public function testMultiElementSingleLineArraysAreFixed(): void
+    {
+        $report = self::checkFile(__DIR__ . '/__fixtures__/multiElementSingleLine.php');
+
+        Assert::assertSame(3, $report->getErrorCount());
+
+        self::assertSniffError($report, 5, ArrayFormattingSniff::CODE_MULTI_ELEMENT_NOT_MULTILINE);
+        self::assertSniffError($report, 7, ArrayFormattingSniff::CODE_MULTI_ELEMENT_NOT_MULTILINE);
+        self::assertSniffError($report, 9, ArrayFormattingSniff::CODE_MULTI_ELEMENT_NOT_MULTILINE);
+
+        self::assertAllFixedInFile($report);
+    }
+
+
+    public function testNestedArraysAreFixed(): void
+    {
+        $report = self::checkFile(__DIR__ . '/__fixtures__/nestedArrays.php');
+
+        Assert::assertSame(10, $report->getErrorCount());
+
+        self::assertSniffError($report, 6, ArrayFormattingSniff::CODE_NESTED_NOT_MULTILINE);
+        self::assertSniffError($report, 9, ArrayFormattingSniff::CODE_NESTED_NOT_MULTILINE);
+        self::assertSniffError($report, 12, ArrayFormattingSniff::CODE_SINGLE_ELEMENT_NOT_INLINE);
+        self::assertSniffError($report, 17, ArrayFormattingSniff::CODE_NESTED_NOT_MULTILINE);
+        self::assertSniffError($report, 20, ArrayFormattingSniff::CODE_NESTED_NOT_MULTILINE);
+        self::assertSniffError($report, 23, ArrayFormattingSniff::CODE_NESTED_NOT_MULTILINE);
+        self::assertSniffError($report, 26, ArrayFormattingSniff::CODE_NESTED_NOT_MULTILINE);
+        self::assertSniffError($report, 29, ArrayFormattingSniff::CODE_NESTED_NOT_MULTILINE);
+        self::assertSniffError($report, 29, ArrayFormattingSniff::CODE_MULTI_ELEMENT_NOT_MULTILINE);
+
+        self::assertAllFixedInFile($report);
+    }
+
+
+    public function testEdgeCasesAreFixed(): void
+    {
+        $report = self::checkFile(__DIR__ . '/__fixtures__/edgeCases.php');
+
+        Assert::assertSame(7, $report->getErrorCount());
+
+        self::assertSniffError($report, 6, ArrayFormattingSniff::CODE_MULTI_ELEMENT_NOT_MULTILINE);
+        self::assertSniffError($report, 9, ArrayFormattingSniff::CODE_MULTI_ELEMENT_NOT_MULTILINE);
+        self::assertSniffError($report, 12, ArrayFormattingSniff::CODE_MULTI_ELEMENT_NOT_MULTILINE);
+        self::assertSniffError($report, 15, ArrayFormattingSniff::CODE_MULTI_ELEMENT_NOT_MULTILINE);
+        self::assertSniffError($report, 18, ArrayFormattingSniff::CODE_NESTED_NOT_MULTILINE);
+        self::assertSniffError($report, 21, ArrayFormattingSniff::CODE_MULTI_ELEMENT_NOT_MULTILINE);
+        self::assertSniffError($report, 24, ArrayFormattingSniff::CODE_MULTI_ELEMENT_NOT_MULTILINE);
+
+        self::assertAllFixedInFile($report);
+    }
+}

--- a/src/BrandEmbassyCodingStandard/Sniffs/Arrays/ArrayFormatting/__fixtures__/correctFormatting.php
+++ b/src/BrandEmbassyCodingStandard/Sniffs/Arrays/ArrayFormatting/__fixtures__/correctFormatting.php
@@ -1,0 +1,54 @@
+<?php declare(strict_types = 1);
+
+namespace BrandEmbassyCodingStandard\Sniffs\Arrays\ArrayFormatting\__fixtures__;
+
+// Empty arrays
+$empty = [];
+
+// Single element inline - correct
+$a = ['one'];
+$b = ['key' => 'value'];
+$c = [1];
+
+// Multi element multiline - correct
+$d = [
+    'one',
+    'two',
+    'three',
+];
+
+$e = [
+    'key1' => 'value1',
+    'key2' => 'value2',
+];
+
+// Nested arrays - correct
+$f = [
+    ['one'],
+    ['two'],
+];
+
+$g = [
+    'key' => ['nested'],
+];
+
+// Single element with multiline content - correct (cannot be inlined)
+$h = [
+    [
+        'one',
+        'two',
+    ],
+];
+
+// Edge cases - correct
+$i = foo(['single']);
+$j = [...$items];
+$k = [fn() => 'x'];
+foo([
+    'a',
+    'b',
+]);
+$l = [
+    ...$items,
+    ...$more,
+];

--- a/src/BrandEmbassyCodingStandard/Sniffs/Arrays/ArrayFormatting/__fixtures__/edgeCases.fixed.php
+++ b/src/BrandEmbassyCodingStandard/Sniffs/Arrays/ArrayFormatting/__fixtures__/edgeCases.fixed.php
@@ -1,0 +1,44 @@
+<?php declare(strict_types = 1);
+
+namespace BrandEmbassyCodingStandard\Sniffs\Arrays\ArrayFormatting\__fixtures__;
+
+// Array in function argument - multi-element
+foo([
+    'a',
+    'b',
+]);
+
+// Array in method call - multi-element
+$obj->method([
+    'a',
+    'b',
+]);
+
+// Spread operator - multi-element
+$a = [
+    ...$items,
+    ...$more,
+];
+
+// Arrow functions - multi-element
+$b = [
+    fn() => 'x',
+    fn() => 'y',
+];
+
+// Arrow function returning nested array - must be multiline
+$c = [
+    fn() => ['nested'],
+];
+
+// Inline comment between elements
+$d = [
+    'a' /* comment */,
+    'b',
+];
+
+// Constant declaration
+const FOO = [
+    'a',
+    'b',
+];

--- a/src/BrandEmbassyCodingStandard/Sniffs/Arrays/ArrayFormatting/__fixtures__/edgeCases.php
+++ b/src/BrandEmbassyCodingStandard/Sniffs/Arrays/ArrayFormatting/__fixtures__/edgeCases.php
@@ -1,0 +1,24 @@
+<?php declare(strict_types = 1);
+
+namespace BrandEmbassyCodingStandard\Sniffs\Arrays\ArrayFormatting\__fixtures__;
+
+// Array in function argument - multi-element
+foo(['a', 'b']);
+
+// Array in method call - multi-element
+$obj->method(['a', 'b']);
+
+// Spread operator - multi-element
+$a = [...$items, ...$more];
+
+// Arrow functions - multi-element
+$b = [fn() => 'x', fn() => 'y'];
+
+// Arrow function returning nested array - must be multiline
+$c = [fn() => ['nested']];
+
+// Inline comment between elements
+$d = ['a' /* comment */, 'b'];
+
+// Constant declaration
+const FOO = ['a', 'b'];

--- a/src/BrandEmbassyCodingStandard/Sniffs/Arrays/ArrayFormatting/__fixtures__/multiElementSingleLine.fixed.php
+++ b/src/BrandEmbassyCodingStandard/Sniffs/Arrays/ArrayFormatting/__fixtures__/multiElementSingleLine.fixed.php
@@ -1,0 +1,19 @@
+<?php declare(strict_types = 1);
+
+namespace BrandEmbassyCodingStandard\Sniffs\Arrays\ArrayFormatting\__fixtures__;
+
+$a = [
+    'one',
+    'two',
+    'three',
+];
+
+$b = [
+    'key1' => 'value1',
+    'key2' => 'value2',
+];
+
+$c = [
+    1,
+    2,
+];

--- a/src/BrandEmbassyCodingStandard/Sniffs/Arrays/ArrayFormatting/__fixtures__/multiElementSingleLine.php
+++ b/src/BrandEmbassyCodingStandard/Sniffs/Arrays/ArrayFormatting/__fixtures__/multiElementSingleLine.php
@@ -1,0 +1,9 @@
+<?php declare(strict_types = 1);
+
+namespace BrandEmbassyCodingStandard\Sniffs\Arrays\ArrayFormatting\__fixtures__;
+
+$a = ['one', 'two', 'three'];
+
+$b = ['key1' => 'value1', 'key2' => 'value2'];
+
+$c = [1, 2];

--- a/src/BrandEmbassyCodingStandard/Sniffs/Arrays/ArrayFormatting/__fixtures__/nestedArrays.fixed.php
+++ b/src/BrandEmbassyCodingStandard/Sniffs/Arrays/ArrayFormatting/__fixtures__/nestedArrays.fixed.php
@@ -1,0 +1,50 @@
+<?php declare(strict_types = 1);
+
+namespace BrandEmbassyCodingStandard\Sniffs\Arrays\ArrayFormatting\__fixtures__;
+
+// Nested multi-element on single line - nested check fires first
+$a = [
+    ['one'],
+    ['two'],
+];
+
+// Single element with nested array inline - must be multiline
+$b = [
+    'key' => ['nested'],
+];
+
+// Single element with single-line content on multiple lines (no nesting)
+$c = ['only-one'];
+
+// Deeply nested arrays - both outer and middle must be multiline
+$d = [
+    'key' => [
+        'inner' => ['deep'],
+    ],
+];
+
+// Multi-element with nested array - nested check fires
+$e = [
+    'a',
+    ['b'],
+];
+
+// Multi keyed with nested values inline - must be multiline
+$f = [
+    'k1' => ['a'],
+    'k2' => ['b'],
+];
+
+// Mixed: some values plain, some nested - must be multiline
+$g = [
+    'k1' => 'v1',
+    'k2' => ['nested'],
+];
+
+// Single keyed, value is multi-element array - outer must be multiline, inner must be multiline
+$h = [
+    'key' => [
+        'a',
+        'b',
+    ],
+];

--- a/src/BrandEmbassyCodingStandard/Sniffs/Arrays/ArrayFormatting/__fixtures__/nestedArrays.php
+++ b/src/BrandEmbassyCodingStandard/Sniffs/Arrays/ArrayFormatting/__fixtures__/nestedArrays.php
@@ -1,0 +1,29 @@
+<?php declare(strict_types = 1);
+
+namespace BrandEmbassyCodingStandard\Sniffs\Arrays\ArrayFormatting\__fixtures__;
+
+// Nested multi-element on single line - nested check fires first
+$a = [['one'], ['two']];
+
+// Single element with nested array inline - must be multiline
+$b = ['key' => ['nested']];
+
+// Single element with single-line content on multiple lines (no nesting)
+$c = [
+    'only-one',
+];
+
+// Deeply nested arrays - both outer and middle must be multiline
+$d = ['key' => ['inner' => ['deep']]];
+
+// Multi-element with nested array - nested check fires
+$e = ['a', ['b']];
+
+// Multi keyed with nested values inline - must be multiline
+$f = ['k1' => ['a'], 'k2' => ['b']];
+
+// Mixed: some values plain, some nested - must be multiline
+$g = ['k1' => 'v1', 'k2' => ['nested']];
+
+// Single keyed, value is multi-element array - outer must be multiline, inner must be multiline
+$h = ['key' => ['a', 'b']];

--- a/src/BrandEmbassyCodingStandard/Sniffs/Arrays/ArrayFormatting/__fixtures__/singleElementMultiline.fixed.php
+++ b/src/BrandEmbassyCodingStandard/Sniffs/Arrays/ArrayFormatting/__fixtures__/singleElementMultiline.fixed.php
@@ -1,0 +1,9 @@
+<?php declare(strict_types = 1);
+
+namespace BrandEmbassyCodingStandard\Sniffs\Arrays\ArrayFormatting\__fixtures__;
+
+$a = ['one'];
+
+$b = ['key' => 'value'];
+
+$c = [1];

--- a/src/BrandEmbassyCodingStandard/Sniffs/Arrays/ArrayFormatting/__fixtures__/singleElementMultiline.php
+++ b/src/BrandEmbassyCodingStandard/Sniffs/Arrays/ArrayFormatting/__fixtures__/singleElementMultiline.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types = 1);
+
+namespace BrandEmbassyCodingStandard\Sniffs\Arrays\ArrayFormatting\__fixtures__;
+
+$a = [
+    'one',
+];
+
+$b = [
+    'key' => 'value',
+];
+
+$c = [
+    1,
+];

--- a/src/BrandEmbassyCodingStandard/Sniffs/Classes/ClassesWithoutSelfReferencingSniff.php
+++ b/src/BrandEmbassyCodingStandard/Sniffs/Classes/ClassesWithoutSelfReferencingSniff.php
@@ -145,7 +145,10 @@ class ClassesWithoutSelfReferencingSniff implements Sniff
         $previousPointer = TokenHelper::findPreviousEffective($phpcsFile, $doubleColonPointer - 1);
         assert($previousPointer !== null);
 
-        if (!in_array($tokens[$previousPointer]['code'], [T_STATIC, T_SELF], true)) {
+        if (!in_array($tokens[$previousPointer]['code'], [
+            T_STATIC,
+            T_SELF,
+        ], true)) {
             return null;
         }
 

--- a/src/BrandEmbassyCodingStandard/Sniffs/Classes/TraitUsePositionSniff.php
+++ b/src/BrandEmbassyCodingStandard/Sniffs/Classes/TraitUsePositionSniff.php
@@ -25,7 +25,11 @@ class TraitUsePositionSniff implements Sniff
      */
     public function register(): array
     {
-        return [T_CLASS, T_ANON_CLASS, T_TRAIT];
+        return [
+            T_CLASS,
+            T_ANON_CLASS,
+            T_TRAIT,
+        ];
     }
 
 

--- a/src/BrandEmbassyCodingStandard/Sniffs/Classes/TraitUseSpacingSniff.php
+++ b/src/BrandEmbassyCodingStandard/Sniffs/Classes/TraitUseSpacingSniff.php
@@ -53,7 +53,11 @@ class TraitUseSpacingSniff implements Sniff
      */
     public function register(): array
     {
-        return [T_CLASS, T_ANON_CLASS, T_TRAIT];
+        return [
+            T_CLASS,
+            T_ANON_CLASS,
+            T_TRAIT,
+        ];
     }
 
 
@@ -154,7 +158,10 @@ class TraitUseSpacingSniff implements Sniff
         /** @var int $lastUseEndPointer */
         $lastUseEndPointer = TokenHelper::findNextLocal(
             $phpcsFile,
-            [T_SEMICOLON, T_OPEN_CURLY_BRACKET],
+            [
+                T_SEMICOLON,
+                T_OPEN_CURLY_BRACKET,
+            ],
             $lastUsePointer + 1,
         );
         if ($tokens[$lastUseEndPointer]['code'] === T_OPEN_CURLY_BRACKET) {
@@ -230,7 +237,10 @@ class TraitUseSpacingSniff implements Sniff
             return SniffSettingsHelper::normalizeInteger($this->linesCountAfterLastUseWhenLastInClass);
         }
 
-        $followingPointers = TokenHelper::findNextAll($phpcsFile, [T_VARIABLE, T_CONST], $lastUseEndPointer);
+        $followingPointers = TokenHelper::findNextAll($phpcsFile, [
+            T_VARIABLE,
+            T_CONST,
+        ], $lastUseEndPointer);
 
         if ($followingPointers === []) {
             return SniffSettingsHelper::normalizeInteger($this->linesCountAfterLastUse);
@@ -271,7 +281,10 @@ class TraitUseSpacingSniff implements Sniff
             /** @var int $previousUseEndPointer */
             $previousUseEndPointer = TokenHelper::findNextLocal(
                 $phpcsFile,
-                [T_SEMICOLON, T_OPEN_CURLY_BRACKET],
+                [
+                    T_SEMICOLON,
+                    T_OPEN_CURLY_BRACKET,
+                ],
                 $previousUsePointer + 1,
             );
             if ($tokens[$previousUseEndPointer]['code'] === T_OPEN_CURLY_BRACKET) {


### PR DESCRIPTION
## Summary

New PHP_CodeSniffer sniff (`ArrayFormattingSniff`) that enforces consistent array formatting:

- **Single-element arrays** must be inline: `['one']` or `['key' => 'value']`
- **Multi-element arrays** must have each element on its own line
- **Arrays containing nested arrays** must always be multiline (even with a single element)

Single-element arrays whose content is inherently multiline (e.g. contains a multiline closure or nested multiline array) are left as-is.

All three rules include automatic fixers (`--fix`).

## Changes

- `src/.../Arrays/ArrayFormatting/ArrayFormattingSniff.php` — the sniff implementation
- `src/.../Arrays/ArrayFormatting/ArrayFormattingSniffTest.php` — 5 test methods, 57 assertions
- `__fixtures__/` — 9 fixture files covering correct formatting, violations, and fixes
- `default-ecs.php` — registered the new rule

## Test coverage

| Fixture | What it tests |
|---------|--------------|
| `correctFormatting` | Empty, inline single, multiline multi, nested multiline, spread, arrow fn, function args |
| `singleElementMultiline` | Single-element arrays incorrectly on multiple lines → fixed to inline |
| `multiElementSingleLine` | Multi-element arrays on one line → fixed to multiline |
| `nestedArrays` | Nested inline, deeply nested, keyed with nested values, mixed plain/nested |
| `edgeCases` | Function args, method calls, spread operator, arrow functions, inline comments, constants |

## Test plan

- [x] PHPUnit: 85 tests, 188 assertions — all pass
- [x] PHPStan: no errors
- [x] Tested against channel-integrations codebase — correctly detects and fixes violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)