### PR TITLE
Add SingleElementArrayInlineSniff ECS rule

### DIFF
--- a/default-ecs.php
+++ b/default-ecs.php
@@ -1,5 +1,6 @@
 <?php declare(strict_types = 1);
 
+use BrandEmbassyCodingStandard\Sniffs\Arrays\SingleElementArrayInline\SingleElementArrayInlineSniff;
 use BrandEmbassyCodingStandard\Sniffs\Classes\ClassesWithoutSelfReferencingSniff;
 use BrandEmbassyCodingStandard\Sniffs\Classes\FinalClassByAnnotationSniff;
 use BrandEmbassyCodingStandard\Sniffs\Classes\TraitUsePositionSniff;
@@ -239,9 +240,7 @@ return static function (ECSConfig $ecsConfig, string $projectRootPath): array {
     // ]);
 
     // region SetList::CLEAN_CODE
-    $ecsConfig->ruleWithConfiguration(ArraySyntaxFixer::class, [
-        'syntax' => 'short',
-    ]);
+    $ecsConfig->ruleWithConfiguration(ArraySyntaxFixer::class, ['syntax' => 'short']);
     $ecsConfig->rules(
         [
             ParamReturnAndVarTagMalformsFixer::class,
@@ -309,9 +308,7 @@ return static function (ECSConfig $ecsConfig, string $projectRootPath): array {
             'elements' => [TrailingCommaInMultilineFixer::ELEMENTS_ARRAYS],
         ],
     );
-    $ecsConfig->ruleWithConfiguration(ArraySyntaxFixer::class, [
-        'syntax' => 'short',
-    ]);
+    $ecsConfig->ruleWithConfiguration(ArraySyntaxFixer::class, ['syntax' => 'short']);
     // endregion SetList::COMMON - vendor/symplify/easy-coding-standard/config/set/common/array.php
 
     // region SetList::COMMON - vendor/symplify/easy-coding-standard/config/set/common/comments.php
@@ -341,9 +338,7 @@ return static function (ECSConfig $ecsConfig, string $projectRootPath): array {
             'elements' => ['const', 'property'],
         ],
     );
-    $ecsConfig->ruleWithConfiguration(ClassDefinitionFixer::class, [
-        'single_line' => true,
-    ]);
+    $ecsConfig->ruleWithConfiguration(ClassDefinitionFixer::class, ['single_line' => true]);
     $ecsConfig->ruleWithConfiguration(
         YodaStyleFixer::class,
         [
@@ -425,12 +420,8 @@ return static function (ECSConfig $ecsConfig, string $projectRootPath): array {
             ],
         ],
     );
-    $ecsConfig->ruleWithConfiguration(ConcatSpaceFixer::class, [
-        'spacing' => 'one',
-    ]);
-    $ecsConfig->ruleWithConfiguration(SuperfluousWhitespaceSniff::class, [
-        'ignoreBlankLines' => false,
-    ]);
+    $ecsConfig->ruleWithConfiguration(ConcatSpaceFixer::class, ['spacing' => 'one']);
+    $ecsConfig->ruleWithConfiguration(SuperfluousWhitespaceSniff::class, ['ignoreBlankLines' => false]);
     $ecsConfig->ruleWithConfiguration(
         BinaryOperatorSpacesFixer::class,
         [
@@ -455,9 +446,7 @@ return static function (ECSConfig $ecsConfig, string $projectRootPath): array {
     $ecsConfig->ruleWithConfiguration(OrderedImportsFixer::class, [
         'imports_order' => ['class', 'function', 'const'],
     ]);
-    $ecsConfig->ruleWithConfiguration(DeclareEqualNormalizeFixer::class, [
-        'space' => 'none',
-    ]);
+    $ecsConfig->ruleWithConfiguration(DeclareEqualNormalizeFixer::class, ['space' => 'none']);
     $ecsConfig->ruleWithConfiguration(
         BracesFixer::class,
         [
@@ -519,22 +508,16 @@ return static function (ECSConfig $ecsConfig, string $projectRootPath): array {
         VisibilityRequiredFixer::class,
         WhitespaceAfterCommaInArrayFixer::class,
     ]);
-    $ecsConfig->ruleWithConfiguration(MethodArgumentSpaceFixer::class, [
-        'on_multiline' => 'ensure_fully_multiline',
-    ]);
+    $ecsConfig->ruleWithConfiguration(MethodArgumentSpaceFixer::class, ['on_multiline' => 'ensure_fully_multiline']);
     $ecsConfig->ruleWithConfiguration(SingleClassElementPerStatementFixer::class, [
         'elements' => ['property'],
     ]);
-    $ecsConfig->ruleWithConfiguration(ConcatSpaceFixer::class, [
-        'spacing' => 'one',
-    ]);
+    $ecsConfig->ruleWithConfiguration(ConcatSpaceFixer::class, ['spacing' => 'one']);
     $ecsConfig->skip([SingleImportPerStatementFixer::class]);
     // endregion SetList::PSR_12 - vendor/symplify/easy-coding-standard/config/set/psr12.php
 
     // region SetList::DOCTRINE_ANNOTATIONS - vendor/symplify/easy-coding-standard/config/set/doctrine-annotations.php
-    $ecsConfig->ruleWithConfiguration(DoctrineAnnotationIndentationFixer::class, [
-        'indent_mixed_lines' => true,
-    ]);
+    $ecsConfig->ruleWithConfiguration(DoctrineAnnotationIndentationFixer::class, ['indent_mixed_lines' => true]);
     $ecsConfig->ruleWithConfiguration(
         DoctrineAnnotationSpacesFixer::class,
         [
@@ -547,9 +530,7 @@ return static function (ECSConfig $ecsConfig, string $projectRootPath): array {
 
     // region === brand embassy coding standard ===
     $ecsConfig->rule(LineLengthFixer::class);
-    $ecsConfig->ruleWithConfiguration(PhpdocLineSpanFixer::class, [
-        'const' => 'single',
-    ]);
+    $ecsConfig->ruleWithConfiguration(PhpdocLineSpanFixer::class, ['const' => 'single']);
     // Forbid duplicate classes
     $ecsConfig->rule(DuplicateClassNameSniff::class);
     // Forbid `array(...)`
@@ -628,9 +609,7 @@ return static function (ECSConfig $ecsConfig, string $projectRootPath): array {
         'allowMultiline' => true,
     ]);
     // Forbid useless inline string concatenation
-    $ecsConfig->ruleWithConfiguration(ArbitraryParenthesesSpacingSniff::class, [
-        'ignoreNewlines' => true,
-    ]);
+    $ecsConfig->ruleWithConfiguration(ArbitraryParenthesesSpacingSniff::class, ['ignoreNewlines' => true]);
     // Forbid tabs for indentation
     $ecsConfig->rule(DisallowTabIndentSniff::class);
     // Require space after language constructs
@@ -685,9 +664,7 @@ return static function (ECSConfig $ecsConfig, string $projectRootPath): array {
     // Requires use of null coalesce operator when possible
     $ecsConfig->rule(RequireNullCoalesceOperatorSniff::class);
     // Forbid unused use statements
-    $ecsConfig->ruleWithConfiguration(UnusedUsesSniff::class, [
-        'searchAnnotations' => true,
-    ]);
+    $ecsConfig->ruleWithConfiguration(UnusedUsesSniff::class, ['searchAnnotations' => true]);
     // Forbid useless uses of the same namespace
     $ecsConfig->rule(UseFromSameNamespaceSniff::class);
     // Forbid useless unreachable catch blocks
@@ -773,9 +750,7 @@ return static function (ECSConfig $ecsConfig, string $projectRootPath): array {
     // Prohibits multiple traits separated by commas in one use statement
     $ecsConfig->rule(TraitUseDeclarationSniff::class);
     // Looks for unused variables
-    $ecsConfig->ruleWithConfiguration(UnusedVariableSniff::class, [
-        'ignoreUnusedValuesWhenOnlyKeysAreUsedInForeach' => true,
-    ]);
+    $ecsConfig->ruleWithConfiguration(UnusedVariableSniff::class, ['ignoreUnusedValuesWhenOnlyKeysAreUsedInForeach' => true]);
     // Looks for useless parameter default value
     $ecsConfig->rule(UnusedInheritedVariablePassedToClosureSniff::class);
     // Looks for use alias that is same as unqualified name
@@ -785,9 +760,7 @@ return static function (ECSConfig $ecsConfig, string $projectRootPath): array {
     // Requires arrow functions for one-line Closures
     $ecsConfig->rule(RequireArrowFunctionSniff::class);
     // Arrow function formatting
-    $ecsConfig->ruleWithConfiguration(ArrowFunctionDeclarationSniff::class, [
-        'spacesCountAfterKeyword' => 0,
-    ]);
+    $ecsConfig->ruleWithConfiguration(ArrowFunctionDeclarationSniff::class, ['spacesCountAfterKeyword' => 0]);
     // Requires trailing comma in multiline function calls
     $ecsConfig->rule(RequireTrailingCommaInCallSniff::class);
     // Disallows implicit array creation
@@ -812,6 +785,8 @@ return static function (ECSConfig $ecsConfig, string $projectRootPath): array {
     $ecsConfig->rule(CamelCapsFunctionNameSniff::class);
     // Forbid spacing after and before array brackets
     $ecsConfig->rule(ArrayBracketSpacingSniff::class);
+    // Force single-element arrays to be inline
+    $ecsConfig->rule(SingleElementArrayInlineSniff::class);
     // Force array declaration structure
     $ecsConfig->rule(ArrayDeclarationSniff::class);
     // Forbid class being in a file with different name
@@ -831,9 +806,7 @@ return static function (ECSConfig $ecsConfig, string $projectRootPath): array {
     // Force rules for variable comments
     $ecsConfig->rule(VariableCommentSniff::class);
     // Force rules for function argument spacing
-    $ecsConfig->ruleWithConfiguration(FunctionDeclarationArgumentSpacingSniff::class, [
-        'equalsSpacing' => 1,
-    ]);
+    $ecsConfig->ruleWithConfiguration(FunctionDeclarationArgumentSpacingSniff::class, ['equalsSpacing' => 1]);
     // Forbid global functions
     $ecsConfig->rule(GlobalFunctionSniff::class);
     // Force function keyword to be lowercase
@@ -875,15 +848,11 @@ return static function (ECSConfig $ecsConfig, string $projectRootPath): array {
         'spacingBeforeFirst' => 0,
     ]);
     // Forbid spaces around `->` operator
-    $ecsConfig->ruleWithConfiguration(ObjectOperatorSpacingSniff::class, [
-        'ignoreNewlines' => true,
-    ]);
+    $ecsConfig->ruleWithConfiguration(ObjectOperatorSpacingSniff::class, ['ignoreNewlines' => true]);
     // Forbid spaces before semicolon `;`
     $ecsConfig->rule(SemicolonSpacingSniff::class);
     // Forbid superfluous whitespaces
-    $ecsConfig->ruleWithConfiguration(SuperfluousWhitespaceSniff::class, [
-        'ignoreBlankLines' => false,
-    ]);
+    $ecsConfig->ruleWithConfiguration(SuperfluousWhitespaceSniff::class, ['ignoreBlankLines' => false]);
     // Force trait use as first statement in class
     $ecsConfig->rule(TraitUsePositionSniff::class);
     // Require empty newlines after uses
@@ -928,9 +897,7 @@ return static function (ECSConfig $ecsConfig, string $projectRootPath): array {
         'closure_fn_spacing' => 'none',
     ]);
 
-    $ecsConfig->ruleWithConfiguration(CastSpacesFixer::class, [
-        'space' => 'none',
-    ]);
+    $ecsConfig->ruleWithConfiguration(CastSpacesFixer::class, ['space' => 'none']);
 
     // Override configuration from SetList::SYMPLIFY, we don't want to remove the @throws and @group annotations
     $ecsConfig->ruleWithConfiguration(

--- a/ecs.php
+++ b/ecs.php
@@ -21,12 +21,8 @@ return static function (ECSConfig $ecsConfig) use ($defaultEcsConfigurationSetup
         InlineCommentSniff::class => [__DIR__ . '/default-ecs.php'],
         CommentedOutCodeSniff::class => [__DIR__ . '/ecs.php', __DIR__ . '/default-ecs.php'],
         ArrayDeclarationSniff::class => [__DIR__ . '/ecs.php', __DIR__ . '/default-ecs.php'],
-        UnusedFunctionParameterSniff::class . '.FoundInImplementedInterface' => [
-            __DIR__ . '/src/BrandEmbassyCodingStandard/PhpStan/Rules/Method/ImmutableWitherMethodRule.php',
-        ],
-        UnusedFunctionParameterSniff::class . '.FoundInImplementedInterfaceAfterLastUsed' => [
-            __DIR__ . '/src/BrandEmbassyCodingStandard/PhpStan/Rules/Method/ImmutableWitherMethodRule.php',
-        ],
+        UnusedFunctionParameterSniff::class . '.FoundInImplementedInterface' => [__DIR__ . '/src/BrandEmbassyCodingStandard/PhpStan/Rules/Method/ImmutableWitherMethodRule.php'],
+        UnusedFunctionParameterSniff::class . '.FoundInImplementedInterfaceAfterLastUsed' => [__DIR__ . '/src/BrandEmbassyCodingStandard/PhpStan/Rules/Method/ImmutableWitherMethodRule.php'],
         'SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint' => [
             __DIR__ . '/src/BrandEmbassyCodingStandard/Sniffs/Classes/ClassesWithoutSelfReferencingSniff.php',
             __DIR__ . '/src/BrandEmbassyCodingStandard/Sniffs/Classes/FinalClassByAnnotationSniff.php',

--- a/src/BrandEmbassyCodingStandard/Rector/MabeEnumMethodCallToEnumConstRector/MabeEnumMethodCallToEnumConstRector.php
+++ b/src/BrandEmbassyCodingStandard/Rector/MabeEnumMethodCallToEnumConstRector/MabeEnumMethodCallToEnumConstRector.php
@@ -69,9 +69,7 @@ class MabeEnumMethodCallToEnumConstRector extends AbstractRector implements MinP
             new ConfiguredCodeSample(
                 'IgnoredEnum::getValue()',
                 'IgnoredEnum::getValue()',
-                [
-                    self::ARE_CLASSES_FROM_VENDOR_IGNORED => false,
-                ],
+                [self::ARE_CLASSES_FROM_VENDOR_IGNORED => false],
             ),
         ]);
     }

--- a/src/BrandEmbassyCodingStandard/Rector/MabeEnumMethodCallToEnumConstRector/config/configured_rule.php
+++ b/src/BrandEmbassyCodingStandard/Rector/MabeEnumMethodCallToEnumConstRector/config/configured_rule.php
@@ -4,7 +4,5 @@ use BrandEmbassyCodingStandard\Rector\MabeEnumMethodCallToEnumConstRector\MabeEn
 use Rector\Config\RectorConfig;
 
 return static function (RectorConfig $rectorConfig): void {
-    $rectorConfig->ruleWithConfiguration(MabeEnumMethodCallToEnumConstRector::class, [
-        MabeEnumMethodCallToEnumConstRector::ARE_CLASSES_FROM_VENDOR_IGNORED => true,
-    ]);
+    $rectorConfig->ruleWithConfiguration(MabeEnumMethodCallToEnumConstRector::class, [MabeEnumMethodCallToEnumConstRector::ARE_CLASSES_FROM_VENDOR_IGNORED => true]);
 };

--- a/src/BrandEmbassyCodingStandard/Sniffs/Arrays/SingleElementArrayInline/SingleElementArrayInlineSniff.php
+++ b/src/BrandEmbassyCodingStandard/Sniffs/Arrays/SingleElementArrayInline/SingleElementArrayInlineSniff.php
@@ -1,0 +1,260 @@
+<?php declare(strict_types = 1);
+
+namespace BrandEmbassyCodingStandard\Sniffs\Arrays\SingleElementArrayInline;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+use function assert;
+use function is_int;
+use function is_string;
+use function str_contains;
+use const T_COMMA;
+use const T_OPEN_CURLY_BRACKET;
+use const T_OPEN_PARENTHESIS;
+use const T_OPEN_SHORT_ARRAY;
+use const T_WHITESPACE;
+
+class SingleElementArrayInlineSniff implements Sniff
+{
+    public const CODE_SINGLE_ELEMENT_NOT_INLINE = 'SingleElementNotInline';
+
+
+    /**
+     * @return list<int|string>
+     */
+    public function register(): array
+    {
+        return [T_OPEN_SHORT_ARRAY];
+    }
+
+
+    /**
+     * @phpcsSuppress SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint
+     *
+     * @param int $stackPtr
+     */
+    public function process(File $phpcsFile, $stackPtr): void
+    {
+        $tokens = $phpcsFile->getTokens();
+        $opener = $stackPtr;
+
+        /** @var int $closer */
+        $closer = $tokens[$opener]['bracket_closer'];
+
+        $elementCount = $this->countElements($phpcsFile, $opener, $closer);
+
+        if ($elementCount !== 1) {
+            return;
+        }
+
+        $isMultiline = $tokens[$opener]['line'] !== $tokens[$closer]['line'];
+
+        if (!$isMultiline) {
+            return;
+        }
+
+        if ($this->containsNestedArray($phpcsFile, $opener, $closer)) {
+            return;
+        }
+
+        if ($this->elementContentIsMultiline($phpcsFile, $opener, $closer)) {
+            return;
+        }
+
+        $fix = $phpcsFile->addFixableError(
+            'Single-element array must be inline',
+            $opener,
+            self::CODE_SINGLE_ELEMENT_NOT_INLINE,
+        );
+
+        if ($fix) {
+            $this->fixToInline($phpcsFile, $opener, $closer);
+        }
+    }
+
+
+    private function countElements(File $phpcsFile, int $opener, int $closer): int
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        if ($closer - $opener === 1) {
+            return 0;
+        }
+
+        $hasContent = false;
+
+        for ($i = $opener + 1; $i < $closer; $i++) {
+            if ($tokens[$i]['code'] !== T_WHITESPACE) {
+                $hasContent = true;
+                break;
+            }
+        }
+
+        if (!$hasContent) {
+            return 0;
+        }
+
+        $commaCount = 0;
+
+        for ($i = $opener + 1; $i < $closer; $i++) {
+            $code = $tokens[$i]['code'];
+
+            if ($code === T_OPEN_SHORT_ARRAY) {
+                /** @var int $nestedCloser */
+                $nestedCloser = $tokens[$i]['bracket_closer'];
+                $i = $nestedCloser;
+                continue;
+            }
+
+            if ($code === T_OPEN_PARENTHESIS) {
+                /** @var int $parenCloser */
+                $parenCloser = $tokens[$i]['parenthesis_closer'];
+                $i = $parenCloser;
+                continue;
+            }
+
+            if ($code === T_OPEN_CURLY_BRACKET) {
+                /** @var int $curlyCloser */
+                $curlyCloser = $tokens[$i]['bracket_closer'];
+                $i = $curlyCloser;
+                continue;
+            }
+
+            if ($code === T_COMMA) {
+                $commaCount++;
+            }
+        }
+
+        if ($this->hasTrailingComma($phpcsFile, $opener, $closer)) {
+            $commaCount--;
+        }
+
+        return $commaCount + 1;
+    }
+
+
+    private function hasTrailingComma(File $phpcsFile, int $opener, int $closer): bool
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        for ($i = $closer - 1; $i > $opener; $i--) {
+            if ($tokens[$i]['code'] === T_WHITESPACE) {
+                continue;
+            }
+
+            return $tokens[$i]['code'] === T_COMMA;
+        }
+
+        return false;
+    }
+
+
+    private function containsNestedArray(File $phpcsFile, int $opener, int $closer): bool
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        for ($i = $opener + 1; $i < $closer; $i++) {
+            if ($tokens[$i]['code'] === T_OPEN_SHORT_ARRAY) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+
+    private function elementContentIsMultiline(File $phpcsFile, int $opener, int $closer): bool
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        $firstContent = null;
+        $lastContent = null;
+
+        for ($i = $opener + 1; $i < $closer; $i++) {
+            if ($tokens[$i]['code'] !== T_WHITESPACE) {
+                if ($firstContent === null) {
+                    $firstContent = $i;
+                }
+
+                $lastContent = $i;
+            }
+        }
+
+        if ($firstContent === null || $lastContent === null) {
+            return false;
+        }
+
+        // Exclude trailing comma from the check
+        if ($tokens[$lastContent]['code'] === T_COMMA) {
+            for ($i = $lastContent - 1; $i > $opener; $i--) {
+                if ($tokens[$i]['code'] !== T_WHITESPACE) {
+                    $lastContent = $i;
+                    break;
+                }
+            }
+        }
+
+        return $tokens[$firstContent]['line'] !== $tokens[$lastContent]['line'];
+    }
+
+
+    private function fixToInline(File $phpcsFile, int $opener, int $closer): void
+    {
+        $tokens = $phpcsFile->getTokens();
+        $phpcsFile->fixer->beginChangeset();
+
+        $firstContent = null;
+        $lastContent = null;
+        $trailingCommaPos = null;
+
+        for ($i = $opener + 1; $i < $closer; $i++) {
+            if ($tokens[$i]['code'] !== T_WHITESPACE) {
+                if ($firstContent === null) {
+                    $firstContent = $i;
+                }
+
+                $lastContent = $i;
+            }
+        }
+
+        if ($this->hasTrailingComma($phpcsFile, $opener, $closer)) {
+            $trailingCommaPos = $lastContent;
+            assert(is_int($trailingCommaPos));
+            // Find the actual last content before the trailing comma
+            for ($i = $trailingCommaPos - 1; $i > $opener; $i--) {
+                if ($tokens[$i]['code'] !== T_WHITESPACE) {
+                    $lastContent = $i;
+                    break;
+                }
+            }
+        }
+
+        for ($i = $opener + 1; $i < $closer; $i++) {
+            // Remove trailing comma
+            if ($trailingCommaPos !== null && $i === $trailingCommaPos) {
+                $phpcsFile->fixer->replaceToken($i, '');
+                continue;
+            }
+
+            if ($tokens[$i]['code'] !== T_WHITESPACE) {
+                continue;
+            }
+
+            // Remove all whitespace before first content and after last content
+            if ($firstContent !== null && $lastContent !== null && ($i < $firstContent || $i > $lastContent)) {
+                $phpcsFile->fixer->replaceToken($i, '');
+                continue;
+            }
+
+            // For whitespace between content tokens, collapse newlines to space
+            $content = $tokens[$i]['content'];
+            assert(is_string($content));
+
+            if (str_contains($content, "\n")) {
+                $phpcsFile->fixer->replaceToken($i, ' ');
+            }
+        }
+
+        $phpcsFile->fixer->endChangeset();
+    }
+}

--- a/src/BrandEmbassyCodingStandard/Sniffs/Arrays/SingleElementArrayInline/SingleElementArrayInlineSniffTest.php
+++ b/src/BrandEmbassyCodingStandard/Sniffs/Arrays/SingleElementArrayInline/SingleElementArrayInlineSniffTest.php
@@ -1,0 +1,32 @@
+<?php declare(strict_types = 1);
+
+namespace BrandEmbassyCodingStandard\Sniffs\Arrays\SingleElementArrayInline;
+
+use PHPUnit\Framework\Assert;
+use SlevomatCodingStandard\Sniffs\TestCase;
+
+/**
+ * @final
+ */
+class SingleElementArrayInlineSniffTest extends TestCase
+{
+    public function testCorrectFormattingProducesNoErrors(): void
+    {
+        $report = self::checkFile(__DIR__ . '/__fixtures__/correctFormatting.php');
+        self::assertNoSniffErrorInFile($report);
+    }
+
+
+    public function testSingleElementMultilineArraysAreFixed(): void
+    {
+        $report = self::checkFile(__DIR__ . '/__fixtures__/singleElementMultiline.php');
+
+        Assert::assertSame(3, $report->getErrorCount());
+
+        self::assertSniffError($report, 5, SingleElementArrayInlineSniff::CODE_SINGLE_ELEMENT_NOT_INLINE);
+        self::assertSniffError($report, 9, SingleElementArrayInlineSniff::CODE_SINGLE_ELEMENT_NOT_INLINE);
+        self::assertSniffError($report, 13, SingleElementArrayInlineSniff::CODE_SINGLE_ELEMENT_NOT_INLINE);
+
+        self::assertAllFixedInFile($report);
+    }
+}

--- a/src/BrandEmbassyCodingStandard/Sniffs/Arrays/SingleElementArrayInline/__fixtures__/correctFormatting.php
+++ b/src/BrandEmbassyCodingStandard/Sniffs/Arrays/SingleElementArrayInline/__fixtures__/correctFormatting.php
@@ -1,0 +1,34 @@
+<?php declare(strict_types = 1);
+
+namespace BrandEmbassyCodingStandard\Sniffs\Arrays\SingleElementArrayInline\__fixtures__;
+
+// Empty arrays
+$empty = [];
+
+// Single element inline - correct
+$a = ['one'];
+$b = ['key' => 'value'];
+$c = [1];
+
+// Multi element multiline - not our concern
+$d = [
+    'one',
+    'two',
+    'three',
+];
+
+// Single element with nested array - skip (handled by NestedArrayMultiline)
+$e = ['key' => ['nested']];
+
+// Single element with multiline content - correct (cannot be inlined)
+$f = [
+    [
+        'one',
+        'two',
+    ],
+];
+
+// Edge cases - correct
+$g = foo(['single']);
+$h = [...$items];
+$i = [fn() => 'x'];

--- a/src/BrandEmbassyCodingStandard/Sniffs/Arrays/SingleElementArrayInline/__fixtures__/singleElementMultiline.fixed.php
+++ b/src/BrandEmbassyCodingStandard/Sniffs/Arrays/SingleElementArrayInline/__fixtures__/singleElementMultiline.fixed.php
@@ -1,0 +1,9 @@
+<?php declare(strict_types = 1);
+
+namespace BrandEmbassyCodingStandard\Sniffs\Arrays\SingleElementArrayInline\__fixtures__;
+
+$a = ['one'];
+
+$b = ['key' => 'value'];
+
+$c = [1];

--- a/src/BrandEmbassyCodingStandard/Sniffs/Arrays/SingleElementArrayInline/__fixtures__/singleElementMultiline.php
+++ b/src/BrandEmbassyCodingStandard/Sniffs/Arrays/SingleElementArrayInline/__fixtures__/singleElementMultiline.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types = 1);
+
+namespace BrandEmbassyCodingStandard\Sniffs\Arrays\SingleElementArrayInline\__fixtures__;
+
+$a = [
+    'one',
+];
+
+$b = [
+    'key' => 'value',
+];
+
+$c = [
+    1,
+];


### PR DESCRIPTION
Description: Add ECS sniff enforcing single-element arrays to be inline
Possible impact: Coding standard enforcement, array formatting

---
## Summary
Adds a new `SingleElementArrayInlineSniff` that enforces arrays with a single element must be written inline (on a single line), not expanded across multiple lines.

**Example:**
```php
// Before (error)
$a = [
    'one',
];

// After (fixed)
$a = ['one'];
```

**Smart guards:**
- Skips arrays containing nested arrays (handled separately by NestedArrayMultilineSniff)
- Skips arrays where element content itself spans multiple lines (e.g., multiline closures)

## Changes
- **New sniff**: `SingleElementArrayInlineSniff` with fixable error and auto-fixer
- **Tests**: Comprehensive test suite with correctFormatting and singleElementMultiline fixtures
- **Registered** in `default-ecs.php`
- **Self-fixes** applied to existing code in the repository

This is part 1 of 3 - split from the combined ArrayFormattingSniff (PR #119):
1. **SingleElementArrayInlineSniff** (this PR)
2. MultiElementArrayMultilineSniff
3. NestedArrayMultilineSniff

🤖 Generated with [Claude Code](https://claude.com/claude-code)