### PR TITLE
Add MultiElementArrayMultilineSniff ECS rule

### DIFF
--- a/default-ecs.php
+++ b/default-ecs.php
@@ -1,5 +1,6 @@
 <?php declare(strict_types = 1);
 
+use BrandEmbassyCodingStandard\Sniffs\Arrays\MultiElementArrayMultiline\MultiElementArrayMultilineSniff;
 use BrandEmbassyCodingStandard\Sniffs\Classes\ClassesWithoutSelfReferencingSniff;
 use BrandEmbassyCodingStandard\Sniffs\Classes\FinalClassByAnnotationSniff;
 use BrandEmbassyCodingStandard\Sniffs\Classes\TraitUsePositionSniff;
@@ -279,7 +280,14 @@ return static function (ECSConfig $ecsConfig, string $projectRootPath): array {
     $ecsConfig->ruleWithConfiguration(
         GeneralPhpdocAnnotationRemoveFixer::class,
         [
-            'annotations' => ['throws', 'author', 'package', 'group', 'covers', 'category'],
+            'annotations' => [
+                'throws',
+                'author',
+                'package',
+                'group',
+                'covers',
+                'category',
+            ],
         ],
     );
     // endregion SetList::SYMPLIFY
@@ -300,7 +308,12 @@ return static function (ECSConfig $ecsConfig, string $projectRootPath): array {
     $ecsConfig->ruleWithConfiguration(
         NoTrailingCommaInSinglelineFixer::class,
         [
-            'elements' => ['arguments', 'array_destructuring', 'array', 'group_import'],
+            'elements' => [
+                'arguments',
+                'array_destructuring',
+                'array',
+                'group_import',
+            ],
         ],
     );
     $ecsConfig->ruleWithConfiguration(
@@ -338,7 +351,10 @@ return static function (ECSConfig $ecsConfig, string $projectRootPath): array {
     $ecsConfig->ruleWithConfiguration(
         SingleClassElementPerStatementFixer::class,
         [
-            'elements' => ['const', 'property'],
+            'elements' => [
+                'const',
+                'property',
+            ],
         ],
     );
     $ecsConfig->ruleWithConfiguration(ClassDefinitionFixer::class, [
@@ -388,7 +404,10 @@ return static function (ECSConfig $ecsConfig, string $projectRootPath): array {
     // endregion SetList::COMMON - vendor/symplify/easy-coding-standard/config/set/common/phpunit.php
 
     // region SetList::COMMON - vendor/symplify/easy-coding-standard/config/set/common/namespaces.php
-    $ecsConfig->rules([PhpUnitTestAnnotationFixer::class, PhpUnitSetUpTearDownVisibilityFixer::class]);
+    $ecsConfig->rules([
+        PhpUnitTestAnnotationFixer::class,
+        PhpUnitSetUpTearDownVisibilityFixer::class,
+    ]);
     // endregion SetList::COMMON - vendor/symplify/easy-coding-standard/config/set/common/namespaces.php
 
     // region SetList::COMMON - vendor/symplify/easy-coding-standard/config/set/common/spaces.php
@@ -453,7 +472,11 @@ return static function (ECSConfig $ecsConfig, string $projectRootPath): array {
 
     // region SetList::PSR_12 - vendor/symplify/easy-coding-standard/config/set/psr12.php
     $ecsConfig->ruleWithConfiguration(OrderedImportsFixer::class, [
-        'imports_order' => ['class', 'function', 'const'],
+        'imports_order' => [
+            'class',
+            'function',
+            'const',
+        ],
     ]);
     $ecsConfig->ruleWithConfiguration(DeclareEqualNormalizeFixer::class, [
         'space' => 'none',
@@ -480,7 +503,11 @@ return static function (ECSConfig $ecsConfig, string $projectRootPath): array {
         ],
     );
     $ecsConfig->ruleWithConfiguration(VisibilityRequiredFixer::class, [
-        'elements' => ['const', 'method', 'property'],
+        'elements' => [
+            'const',
+            'method',
+            'property',
+        ],
     ]);
     $ecsConfig->rules([
         BinaryOperatorSpacesFixer::class,
@@ -812,6 +839,8 @@ return static function (ECSConfig $ecsConfig, string $projectRootPath): array {
     $ecsConfig->rule(CamelCapsFunctionNameSniff::class);
     // Forbid spacing after and before array brackets
     $ecsConfig->rule(ArrayBracketSpacingSniff::class);
+    // Force multi-element arrays to be multiline
+    $ecsConfig->rule(MultiElementArrayMultilineSniff::class);
     // Force array declaration structure
     $ecsConfig->rule(ArrayDeclarationSniff::class);
     // Forbid class being in a file with different name
@@ -936,7 +965,12 @@ return static function (ECSConfig $ecsConfig, string $projectRootPath): array {
     $ecsConfig->ruleWithConfiguration(
         GeneralPhpdocAnnotationRemoveFixer::class,
         [
-            'annotations' => ['author', 'package', 'covers', 'category'],
+            'annotations' => [
+                'author',
+                'package',
+                'covers',
+                'category',
+            ],
         ],
     );
 

--- a/ecs.php
+++ b/ecs.php
@@ -19,8 +19,14 @@ return static function (ECSConfig $ecsConfig) use ($defaultEcsConfigurationSetup
 
     $skipList = [
         InlineCommentSniff::class => [__DIR__ . '/default-ecs.php'],
-        CommentedOutCodeSniff::class => [__DIR__ . '/ecs.php', __DIR__ . '/default-ecs.php'],
-        ArrayDeclarationSniff::class => [__DIR__ . '/ecs.php', __DIR__ . '/default-ecs.php'],
+        CommentedOutCodeSniff::class => [
+            __DIR__ . '/ecs.php',
+            __DIR__ . '/default-ecs.php',
+        ],
+        ArrayDeclarationSniff::class => [
+            __DIR__ . '/ecs.php',
+            __DIR__ . '/default-ecs.php',
+        ],
         UnusedFunctionParameterSniff::class . '.FoundInImplementedInterface' => [
             __DIR__ . '/src/BrandEmbassyCodingStandard/PhpStan/Rules/Method/ImmutableWitherMethodRule.php',
         ],

--- a/src/BrandEmbassyCodingStandard/Rector/DisallowConstantsInTestsRector/DisallowConstantsInTestsRector.php
+++ b/src/BrandEmbassyCodingStandard/Rector/DisallowConstantsInTestsRector/DisallowConstantsInTestsRector.php
@@ -72,7 +72,11 @@ final class Foo
 CODE_SAMPLE
                     ,
                     [
-                        self::ALLOWED_PATTERNS => ['vendor/*', 'tests/*', '*Fixture.php'],
+                        self::ALLOWED_PATTERNS => [
+                            'vendor/*',
+                            'tests/*',
+                            '*Fixture.php',
+                        ],
                         self::ALLOWED_CONSTANTS => ['Project\Http\HttpMethod'],
                     ],
                 ),

--- a/src/BrandEmbassyCodingStandard/Sniffs/Arrays/MultiElementArrayMultiline/MultiElementArrayMultilineSniff.php
+++ b/src/BrandEmbassyCodingStandard/Sniffs/Arrays/MultiElementArrayMultiline/MultiElementArrayMultilineSniff.php
@@ -1,0 +1,281 @@
+<?php declare(strict_types = 1);
+
+namespace BrandEmbassyCodingStandard\Sniffs\Arrays\MultiElementArrayMultiline;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+use function assert;
+use function is_string;
+use function str_repeat;
+use function strlen;
+use const T_COMMA;
+use const T_OPEN_CURLY_BRACKET;
+use const T_OPEN_PARENTHESIS;
+use const T_OPEN_SHORT_ARRAY;
+use const T_WHITESPACE;
+
+class MultiElementArrayMultilineSniff implements Sniff
+{
+    public const CODE_MULTI_ELEMENT_NOT_MULTILINE = 'MultiElementNotMultiline';
+
+    private const INDENT_SIZE = 4;
+
+
+    /**
+     * @return list<int|string>
+     */
+    public function register(): array
+    {
+        return [T_OPEN_SHORT_ARRAY];
+    }
+
+
+    /**
+     * @phpcsSuppress SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint
+     *
+     * @param int $stackPtr
+     */
+    public function process(File $phpcsFile, $stackPtr): void
+    {
+        $tokens = $phpcsFile->getTokens();
+        $opener = $stackPtr;
+
+        /** @var int $closer */
+        $closer = $tokens[$opener]['bracket_closer'];
+
+        $elementCount = $this->countElements($phpcsFile, $opener, $closer);
+
+        if ($elementCount <= 1) {
+            return;
+        }
+
+        $isMultiline = $tokens[$opener]['line'] !== $tokens[$closer]['line'];
+
+        if ($isMultiline) {
+            return;
+        }
+
+        $fix = $phpcsFile->addFixableError(
+            'Multi-element array must have each element on its own line',
+            $opener,
+            self::CODE_MULTI_ELEMENT_NOT_MULTILINE,
+        );
+
+        if ($fix) {
+            $this->fixToMultiline($phpcsFile, $opener, $closer);
+        }
+    }
+
+
+    private function countElements(File $phpcsFile, int $opener, int $closer): int
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        if ($closer - $opener === 1) {
+            return 0;
+        }
+
+        $hasContent = false;
+
+        for ($i = $opener + 1; $i < $closer; $i++) {
+            if ($tokens[$i]['code'] !== T_WHITESPACE) {
+                $hasContent = true;
+                break;
+            }
+        }
+
+        if (!$hasContent) {
+            return 0;
+        }
+
+        $commaCount = 0;
+
+        for ($i = $opener + 1; $i < $closer; $i++) {
+            $code = $tokens[$i]['code'];
+
+            if ($code === T_OPEN_SHORT_ARRAY) {
+                /** @var int $nestedCloser */
+                $nestedCloser = $tokens[$i]['bracket_closer'];
+                $i = $nestedCloser;
+                continue;
+            }
+
+            if ($code === T_OPEN_PARENTHESIS) {
+                /** @var int $parenCloser */
+                $parenCloser = $tokens[$i]['parenthesis_closer'];
+                $i = $parenCloser;
+                continue;
+            }
+
+            if ($code === T_OPEN_CURLY_BRACKET) {
+                /** @var int $curlyCloser */
+                $curlyCloser = $tokens[$i]['bracket_closer'];
+                $i = $curlyCloser;
+                continue;
+            }
+
+            if ($code === T_COMMA) {
+                $commaCount++;
+            }
+        }
+
+        if ($this->hasTrailingComma($phpcsFile, $opener, $closer)) {
+            $commaCount--;
+        }
+
+        return $commaCount + 1;
+    }
+
+
+    private function hasTrailingComma(File $phpcsFile, int $opener, int $closer): bool
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        for ($i = $closer - 1; $i > $opener; $i--) {
+            if ($tokens[$i]['code'] === T_WHITESPACE) {
+                continue;
+            }
+
+            return $tokens[$i]['code'] === T_COMMA;
+        }
+
+        return false;
+    }
+
+
+    private function fixToMultiline(File $phpcsFile, int $opener, int $closer): void
+    {
+        $tokens = $phpcsFile->getTokens();
+        $phpcsFile->fixer->beginChangeset();
+
+        $baseIndent = $this->getIndentLevel($phpcsFile, $opener);
+        $elementIndent = str_repeat(' ', $baseIndent + self::INDENT_SIZE);
+        $closerIndent = str_repeat(' ', $baseIndent);
+
+        $phpcsFile->fixer->addContent($opener, "\n" . $elementIndent);
+
+        $this->removeWhitespaceAfter($phpcsFile, $opener, $closer);
+
+        $lastCommaPointer = null;
+
+        for ($i = $opener + 1; $i < $closer; $i++) {
+            $code = $tokens[$i]['code'];
+
+            if ($code === T_OPEN_SHORT_ARRAY) {
+                /** @var int $nestedCloser */
+                $nestedCloser = $tokens[$i]['bracket_closer'];
+                $i = $nestedCloser;
+                continue;
+            }
+
+            if ($code === T_OPEN_PARENTHESIS) {
+                /** @var int $parenCloser */
+                $parenCloser = $tokens[$i]['parenthesis_closer'];
+                $i = $parenCloser;
+                continue;
+            }
+
+            if ($code === T_OPEN_CURLY_BRACKET) {
+                /** @var int $curlyCloser */
+                $curlyCloser = $tokens[$i]['bracket_closer'];
+                $i = $curlyCloser;
+                continue;
+            }
+
+            if ($code === T_COMMA) {
+                $lastCommaPointer = $i;
+
+                $this->removeWhitespaceAfter($phpcsFile, $i, $closer);
+
+                $phpcsFile->fixer->addContent($i, "\n" . $elementIndent);
+            }
+        }
+
+        if (!$this->hasTrailingComma($phpcsFile, $opener, $closer)) {
+            $searchFrom = $lastCommaPointer !== null
+                ? $lastCommaPointer + 1
+                : $opener + 1;
+            $lastElementEnd = $this->findLastNonWhitespace($phpcsFile, $searchFrom, $closer);
+
+            if ($lastElementEnd !== null) {
+                $phpcsFile->fixer->addContent($lastElementEnd, ',');
+            }
+        }
+
+        $this->removeWhitespaceBefore($phpcsFile, $opener, $closer);
+
+        $phpcsFile->fixer->addContentBefore($closer, "\n" . $closerIndent);
+
+        $phpcsFile->fixer->endChangeset();
+    }
+
+
+    private function getIndentLevel(File $phpcsFile, int $stackPtr): int
+    {
+        $tokens = $phpcsFile->getTokens();
+        $line = $tokens[$stackPtr]['line'];
+        $firstOnLine = $stackPtr;
+
+        for ($i = $stackPtr - 1; $i >= 0; $i--) {
+            if ($tokens[$i]['line'] !== $line) {
+                $firstOnLine = $i + 1;
+                break;
+            }
+
+            if ($i === 0) {
+                $firstOnLine = 0;
+            }
+        }
+
+        if ($tokens[$firstOnLine]['code'] === T_WHITESPACE) {
+            $content = $tokens[$firstOnLine]['content'];
+            assert(is_string($content));
+
+            return strlen($content);
+        }
+
+        return 0;
+    }
+
+
+    private function removeWhitespaceAfter(File $phpcsFile, int $position, int $closer): void
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        for ($i = $position + 1; $i < $closer; $i++) {
+            if ($tokens[$i]['code'] !== T_WHITESPACE) {
+                break;
+            }
+
+            $phpcsFile->fixer->replaceToken($i, '');
+        }
+    }
+
+
+    private function removeWhitespaceBefore(File $phpcsFile, int $opener, int $closer): void
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        for ($i = $closer - 1; $i > $opener; $i--) {
+            if ($tokens[$i]['code'] !== T_WHITESPACE) {
+                break;
+            }
+
+            $phpcsFile->fixer->replaceToken($i, '');
+        }
+    }
+
+
+    private function findLastNonWhitespace(File $phpcsFile, int $start, int $end): ?int
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        for ($i = $end - 1; $i >= $start; $i--) {
+            if ($tokens[$i]['code'] !== T_WHITESPACE) {
+                return $i;
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/BrandEmbassyCodingStandard/Sniffs/Arrays/MultiElementArrayMultiline/MultiElementArrayMultilineSniffTest.php
+++ b/src/BrandEmbassyCodingStandard/Sniffs/Arrays/MultiElementArrayMultiline/MultiElementArrayMultilineSniffTest.php
@@ -1,0 +1,49 @@
+<?php declare(strict_types = 1);
+
+namespace BrandEmbassyCodingStandard\Sniffs\Arrays\MultiElementArrayMultiline;
+
+use PHPUnit\Framework\Assert;
+use SlevomatCodingStandard\Sniffs\TestCase;
+
+/**
+ * @final
+ */
+class MultiElementArrayMultilineSniffTest extends TestCase
+{
+    public function testCorrectFormattingProducesNoErrors(): void
+    {
+        $report = self::checkFile(__DIR__ . '/__fixtures__/correctFormatting.php');
+        self::assertNoSniffErrorInFile($report);
+    }
+
+
+    public function testMultiElementSingleLineArraysAreFixed(): void
+    {
+        $report = self::checkFile(__DIR__ . '/__fixtures__/multiElementSingleLine.php');
+
+        Assert::assertSame(3, $report->getErrorCount());
+
+        self::assertSniffError($report, 5, MultiElementArrayMultilineSniff::CODE_MULTI_ELEMENT_NOT_MULTILINE);
+        self::assertSniffError($report, 7, MultiElementArrayMultilineSniff::CODE_MULTI_ELEMENT_NOT_MULTILINE);
+        self::assertSniffError($report, 9, MultiElementArrayMultilineSniff::CODE_MULTI_ELEMENT_NOT_MULTILINE);
+
+        self::assertAllFixedInFile($report);
+    }
+
+
+    public function testEdgeCasesAreFixed(): void
+    {
+        $report = self::checkFile(__DIR__ . '/__fixtures__/edgeCases.php');
+
+        Assert::assertSame(6, $report->getErrorCount());
+
+        self::assertSniffError($report, 5, MultiElementArrayMultilineSniff::CODE_MULTI_ELEMENT_NOT_MULTILINE);
+        self::assertSniffError($report, 8, MultiElementArrayMultilineSniff::CODE_MULTI_ELEMENT_NOT_MULTILINE);
+        self::assertSniffError($report, 11, MultiElementArrayMultilineSniff::CODE_MULTI_ELEMENT_NOT_MULTILINE);
+        self::assertSniffError($report, 14, MultiElementArrayMultilineSniff::CODE_MULTI_ELEMENT_NOT_MULTILINE);
+        self::assertSniffError($report, 17, MultiElementArrayMultilineSniff::CODE_MULTI_ELEMENT_NOT_MULTILINE);
+        self::assertSniffError($report, 20, MultiElementArrayMultilineSniff::CODE_MULTI_ELEMENT_NOT_MULTILINE);
+
+        self::assertAllFixedInFile($report);
+    }
+}

--- a/src/BrandEmbassyCodingStandard/Sniffs/Arrays/MultiElementArrayMultiline/__fixtures__/correctFormatting.php
+++ b/src/BrandEmbassyCodingStandard/Sniffs/Arrays/MultiElementArrayMultiline/__fixtures__/correctFormatting.php
@@ -1,0 +1,33 @@
+<?php declare(strict_types = 1);
+
+namespace BrandEmbassyCodingStandard\Sniffs\Arrays\MultiElementArrayMultiline\__fixtures__;
+
+// Empty arrays
+$empty = [];
+
+// Single element inline - not our concern
+$a = ['one'];
+$b = ['key' => 'value'];
+
+// Multi element multiline - correct
+$c = [
+    'one',
+    'two',
+    'three',
+];
+
+$d = [
+    'key1' => 'value1',
+    'key2' => 'value2',
+];
+
+// Edge cases - correct multiline
+foo([
+    'a',
+    'b',
+]);
+
+$e = [
+    ...$items,
+    ...$more,
+];

--- a/src/BrandEmbassyCodingStandard/Sniffs/Arrays/MultiElementArrayMultiline/__fixtures__/edgeCases.fixed.php
+++ b/src/BrandEmbassyCodingStandard/Sniffs/Arrays/MultiElementArrayMultiline/__fixtures__/edgeCases.fixed.php
@@ -1,0 +1,38 @@
+<?php declare(strict_types = 1);
+
+namespace BrandEmbassyCodingStandard\Sniffs\Arrays\MultiElementArrayMultiline\__fixtures__;
+
+foo([
+    'a',
+    'b',
+]);
+
+// Array in method call
+$obj->method([
+    'a',
+    'b',
+]);
+
+// Spread operator
+$a = [
+    ...$items,
+    ...$more,
+];
+
+// Arrow functions
+$b = [
+    fn() => 'x',
+    fn() => 'y',
+];
+
+// Inline comment between elements
+$c = [
+    'a' /* comment */,
+    'b',
+];
+
+// Constant declaration
+const FOO = [
+    'a',
+    'b',
+];

--- a/src/BrandEmbassyCodingStandard/Sniffs/Arrays/MultiElementArrayMultiline/__fixtures__/edgeCases.php
+++ b/src/BrandEmbassyCodingStandard/Sniffs/Arrays/MultiElementArrayMultiline/__fixtures__/edgeCases.php
@@ -1,0 +1,20 @@
+<?php declare(strict_types = 1);
+
+namespace BrandEmbassyCodingStandard\Sniffs\Arrays\MultiElementArrayMultiline\__fixtures__;
+
+foo(['a', 'b']);
+
+// Array in method call
+$obj->method(['a', 'b']);
+
+// Spread operator
+$a = [...$items, ...$more];
+
+// Arrow functions
+$b = [fn() => 'x', fn() => 'y'];
+
+// Inline comment between elements
+$c = ['a' /* comment */, 'b'];
+
+// Constant declaration
+const FOO = ['a', 'b'];

--- a/src/BrandEmbassyCodingStandard/Sniffs/Arrays/MultiElementArrayMultiline/__fixtures__/multiElementSingleLine.fixed.php
+++ b/src/BrandEmbassyCodingStandard/Sniffs/Arrays/MultiElementArrayMultiline/__fixtures__/multiElementSingleLine.fixed.php
@@ -1,0 +1,19 @@
+<?php declare(strict_types = 1);
+
+namespace BrandEmbassyCodingStandard\Sniffs\Arrays\MultiElementArrayMultiline\__fixtures__;
+
+$a = [
+    'one',
+    'two',
+    'three',
+];
+
+$b = [
+    'key1' => 'value1',
+    'key2' => 'value2',
+];
+
+$c = [
+    1,
+    2,
+];

--- a/src/BrandEmbassyCodingStandard/Sniffs/Arrays/MultiElementArrayMultiline/__fixtures__/multiElementSingleLine.php
+++ b/src/BrandEmbassyCodingStandard/Sniffs/Arrays/MultiElementArrayMultiline/__fixtures__/multiElementSingleLine.php
@@ -1,0 +1,9 @@
+<?php declare(strict_types = 1);
+
+namespace BrandEmbassyCodingStandard\Sniffs\Arrays\MultiElementArrayMultiline\__fixtures__;
+
+$a = ['one', 'two', 'three'];
+
+$b = ['key1' => 'value1', 'key2' => 'value2'];
+
+$c = [1, 2];

--- a/src/BrandEmbassyCodingStandard/Sniffs/Classes/ClassesWithoutSelfReferencingSniff.php
+++ b/src/BrandEmbassyCodingStandard/Sniffs/Classes/ClassesWithoutSelfReferencingSniff.php
@@ -145,7 +145,10 @@ class ClassesWithoutSelfReferencingSniff implements Sniff
         $previousPointer = TokenHelper::findPreviousEffective($phpcsFile, $doubleColonPointer - 1);
         assert($previousPointer !== null);
 
-        if (!in_array($tokens[$previousPointer]['code'], [T_STATIC, T_SELF], true)) {
+        if (!in_array($tokens[$previousPointer]['code'], [
+            T_STATIC,
+            T_SELF,
+        ], true)) {
             return null;
         }
 

--- a/src/BrandEmbassyCodingStandard/Sniffs/Classes/TraitUsePositionSniff.php
+++ b/src/BrandEmbassyCodingStandard/Sniffs/Classes/TraitUsePositionSniff.php
@@ -25,7 +25,11 @@ class TraitUsePositionSniff implements Sniff
      */
     public function register(): array
     {
-        return [T_CLASS, T_ANON_CLASS, T_TRAIT];
+        return [
+            T_CLASS,
+            T_ANON_CLASS,
+            T_TRAIT,
+        ];
     }
 
 

--- a/src/BrandEmbassyCodingStandard/Sniffs/Classes/TraitUseSpacingSniff.php
+++ b/src/BrandEmbassyCodingStandard/Sniffs/Classes/TraitUseSpacingSniff.php
@@ -53,7 +53,11 @@ class TraitUseSpacingSniff implements Sniff
      */
     public function register(): array
     {
-        return [T_CLASS, T_ANON_CLASS, T_TRAIT];
+        return [
+            T_CLASS,
+            T_ANON_CLASS,
+            T_TRAIT,
+        ];
     }
 
 
@@ -154,7 +158,10 @@ class TraitUseSpacingSniff implements Sniff
         /** @var int $lastUseEndPointer */
         $lastUseEndPointer = TokenHelper::findNextLocal(
             $phpcsFile,
-            [T_SEMICOLON, T_OPEN_CURLY_BRACKET],
+            [
+                T_SEMICOLON,
+                T_OPEN_CURLY_BRACKET,
+            ],
             $lastUsePointer + 1,
         );
         if ($tokens[$lastUseEndPointer]['code'] === T_OPEN_CURLY_BRACKET) {
@@ -230,7 +237,10 @@ class TraitUseSpacingSniff implements Sniff
             return SniffSettingsHelper::normalizeInteger($this->linesCountAfterLastUseWhenLastInClass);
         }
 
-        $followingPointers = TokenHelper::findNextAll($phpcsFile, [T_VARIABLE, T_CONST], $lastUseEndPointer);
+        $followingPointers = TokenHelper::findNextAll($phpcsFile, [
+            T_VARIABLE,
+            T_CONST,
+        ], $lastUseEndPointer);
 
         if ($followingPointers === []) {
             return SniffSettingsHelper::normalizeInteger($this->linesCountAfterLastUse);
@@ -271,7 +281,10 @@ class TraitUseSpacingSniff implements Sniff
             /** @var int $previousUseEndPointer */
             $previousUseEndPointer = TokenHelper::findNextLocal(
                 $phpcsFile,
-                [T_SEMICOLON, T_OPEN_CURLY_BRACKET],
+                [
+                    T_SEMICOLON,
+                    T_OPEN_CURLY_BRACKET,
+                ],
                 $previousUsePointer + 1,
             );
             if ($tokens[$previousUseEndPointer]['code'] === T_OPEN_CURLY_BRACKET) {


### PR DESCRIPTION
Description: Add ECS sniff enforcing multi-element arrays to be multiline
Possible impact: Coding standard enforcement, array formatting

---
## Summary
Adds a new `MultiElementArrayMultilineSniff` that enforces arrays with more than one element must have each element on its own line (multiline format).

**Example:**
```php
// Before (error)
$a = ['one', 'two', 'three'];

// After (fixed)
$a = [
    'one',
    'two',
    'three',
];
```

**Works with:**
- Keyed arrays (`'key' => 'value'`)
- Spread operator (`...$items`)
- Arrow functions (`fn() => 'x'`)
- Function/method arguments
- Constant declarations
- Inline comments between elements

## Changes
- **New sniff**: `MultiElementArrayMultilineSniff` with fixable error and auto-fixer
- **Tests**: Comprehensive test suite with correctFormatting, multiElementSingleLine, and edgeCases fixtures
- **Registered** in `default-ecs.php`
- **Self-fixes** applied to existing code in the repository

This is part 2 of 3 - split from the combined ArrayFormattingSniff (PR #119):
1. SingleElementArrayInlineSniff
2. **MultiElementArrayMultilineSniff** (this PR)
3. NestedArrayMultilineSniff

🤖 Generated with [Claude Code](https://claude.com/claude-code)