### PR TITLE
Add NestedArrayMultilineSniff ECS rule

### DIFF
--- a/default-ecs.php
+++ b/default-ecs.php
@@ -1,5 +1,6 @@
 <?php declare(strict_types = 1);
 
+use BrandEmbassyCodingStandard\Sniffs\Arrays\NestedArrayMultiline\NestedArrayMultilineSniff;
 use BrandEmbassyCodingStandard\Sniffs\Classes\ClassesWithoutSelfReferencingSniff;
 use BrandEmbassyCodingStandard\Sniffs\Classes\FinalClassByAnnotationSniff;
 use BrandEmbassyCodingStandard\Sniffs\Classes\TraitUsePositionSniff;
@@ -812,6 +813,8 @@ return static function (ECSConfig $ecsConfig, string $projectRootPath): array {
     $ecsConfig->rule(CamelCapsFunctionNameSniff::class);
     // Forbid spacing after and before array brackets
     $ecsConfig->rule(ArrayBracketSpacingSniff::class);
+    // Force arrays containing nested arrays to be multiline
+    $ecsConfig->rule(NestedArrayMultilineSniff::class);
     // Force array declaration structure
     $ecsConfig->rule(ArrayDeclarationSniff::class);
     // Forbid class being in a file with different name

--- a/src/BrandEmbassyCodingStandard/Sniffs/Arrays/NestedArrayMultiline/NestedArrayMultilineSniff.php
+++ b/src/BrandEmbassyCodingStandard/Sniffs/Arrays/NestedArrayMultiline/NestedArrayMultilineSniff.php
@@ -1,0 +1,255 @@
+<?php declare(strict_types = 1);
+
+namespace BrandEmbassyCodingStandard\Sniffs\Arrays\NestedArrayMultiline;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+use function assert;
+use function is_string;
+use function str_repeat;
+use function strlen;
+use const T_COMMA;
+use const T_OPEN_CURLY_BRACKET;
+use const T_OPEN_PARENTHESIS;
+use const T_OPEN_SHORT_ARRAY;
+use const T_WHITESPACE;
+
+class NestedArrayMultilineSniff implements Sniff
+{
+    public const CODE_NESTED_NOT_MULTILINE = 'NestedNotMultiline';
+
+    private const INDENT_SIZE = 4;
+
+
+    /**
+     * @return list<int|string>
+     */
+    public function register(): array
+    {
+        return [T_OPEN_SHORT_ARRAY];
+    }
+
+
+    /**
+     * @phpcsSuppress SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint
+     *
+     * @param int $stackPtr
+     */
+    public function process(File $phpcsFile, $stackPtr): void
+    {
+        $tokens = $phpcsFile->getTokens();
+        $opener = $stackPtr;
+
+        /** @var int $closer */
+        $closer = $tokens[$opener]['bracket_closer'];
+
+        if ($this->isEmpty($phpcsFile, $opener, $closer)) {
+            return;
+        }
+
+        $isMultiline = $tokens[$opener]['line'] !== $tokens[$closer]['line'];
+
+        if ($isMultiline) {
+            return;
+        }
+
+        if (!$this->containsNestedArray($phpcsFile, $opener, $closer)) {
+            return;
+        }
+
+        $fix = $phpcsFile->addFixableError(
+            'Array containing nested array must be multiline',
+            $opener,
+            self::CODE_NESTED_NOT_MULTILINE,
+        );
+
+        if ($fix) {
+            $this->fixToMultiline($phpcsFile, $opener, $closer);
+        }
+    }
+
+
+    private function isEmpty(File $phpcsFile, int $opener, int $closer): bool
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        if ($closer - $opener === 1) {
+            return true;
+        }
+
+        for ($i = $opener + 1; $i < $closer; $i++) {
+            if ($tokens[$i]['code'] !== T_WHITESPACE) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+
+    private function containsNestedArray(File $phpcsFile, int $opener, int $closer): bool
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        for ($i = $opener + 1; $i < $closer; $i++) {
+            if ($tokens[$i]['code'] === T_OPEN_SHORT_ARRAY) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+
+    private function hasTrailingComma(File $phpcsFile, int $opener, int $closer): bool
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        for ($i = $closer - 1; $i > $opener; $i--) {
+            if ($tokens[$i]['code'] === T_WHITESPACE) {
+                continue;
+            }
+
+            return $tokens[$i]['code'] === T_COMMA;
+        }
+
+        return false;
+    }
+
+
+    private function fixToMultiline(File $phpcsFile, int $opener, int $closer): void
+    {
+        $tokens = $phpcsFile->getTokens();
+        $phpcsFile->fixer->beginChangeset();
+
+        $baseIndent = $this->getIndentLevel($phpcsFile, $opener);
+        $elementIndent = str_repeat(' ', $baseIndent + self::INDENT_SIZE);
+        $closerIndent = str_repeat(' ', $baseIndent);
+
+        $phpcsFile->fixer->addContent($opener, "\n" . $elementIndent);
+
+        $this->removeWhitespaceAfter($phpcsFile, $opener, $closer);
+
+        $lastCommaPointer = null;
+
+        for ($i = $opener + 1; $i < $closer; $i++) {
+            $code = $tokens[$i]['code'];
+
+            if ($code === T_OPEN_SHORT_ARRAY) {
+                /** @var int $nestedCloser */
+                $nestedCloser = $tokens[$i]['bracket_closer'];
+                $i = $nestedCloser;
+                continue;
+            }
+
+            if ($code === T_OPEN_PARENTHESIS) {
+                /** @var int $parenCloser */
+                $parenCloser = $tokens[$i]['parenthesis_closer'];
+                $i = $parenCloser;
+                continue;
+            }
+
+            if ($code === T_OPEN_CURLY_BRACKET) {
+                /** @var int $curlyCloser */
+                $curlyCloser = $tokens[$i]['bracket_closer'];
+                $i = $curlyCloser;
+                continue;
+            }
+
+            if ($code === T_COMMA) {
+                $lastCommaPointer = $i;
+
+                $this->removeWhitespaceAfter($phpcsFile, $i, $closer);
+
+                $phpcsFile->fixer->addContent($i, "\n" . $elementIndent);
+            }
+        }
+
+        if (!$this->hasTrailingComma($phpcsFile, $opener, $closer)) {
+            $searchFrom = $lastCommaPointer !== null
+                ? $lastCommaPointer + 1
+                : $opener + 1;
+            $lastElementEnd = $this->findLastNonWhitespace($phpcsFile, $searchFrom, $closer);
+
+            if ($lastElementEnd !== null) {
+                $phpcsFile->fixer->addContent($lastElementEnd, ',');
+            }
+        }
+
+        $this->removeWhitespaceBefore($phpcsFile, $opener, $closer);
+
+        $phpcsFile->fixer->addContentBefore($closer, "\n" . $closerIndent);
+
+        $phpcsFile->fixer->endChangeset();
+    }
+
+
+    private function getIndentLevel(File $phpcsFile, int $stackPtr): int
+    {
+        $tokens = $phpcsFile->getTokens();
+        $line = $tokens[$stackPtr]['line'];
+        $firstOnLine = $stackPtr;
+
+        for ($i = $stackPtr - 1; $i >= 0; $i--) {
+            if ($tokens[$i]['line'] !== $line) {
+                $firstOnLine = $i + 1;
+                break;
+            }
+
+            if ($i === 0) {
+                $firstOnLine = 0;
+            }
+        }
+
+        if ($tokens[$firstOnLine]['code'] === T_WHITESPACE) {
+            $content = $tokens[$firstOnLine]['content'];
+            assert(is_string($content));
+
+            return strlen($content);
+        }
+
+        return 0;
+    }
+
+
+    private function removeWhitespaceAfter(File $phpcsFile, int $position, int $closer): void
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        for ($i = $position + 1; $i < $closer; $i++) {
+            if ($tokens[$i]['code'] !== T_WHITESPACE) {
+                break;
+            }
+
+            $phpcsFile->fixer->replaceToken($i, '');
+        }
+    }
+
+
+    private function removeWhitespaceBefore(File $phpcsFile, int $opener, int $closer): void
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        for ($i = $closer - 1; $i > $opener; $i--) {
+            if ($tokens[$i]['code'] !== T_WHITESPACE) {
+                break;
+            }
+
+            $phpcsFile->fixer->replaceToken($i, '');
+        }
+    }
+
+
+    private function findLastNonWhitespace(File $phpcsFile, int $start, int $end): ?int
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        for ($i = $end - 1; $i >= $start; $i--) {
+            if ($tokens[$i]['code'] !== T_WHITESPACE) {
+                return $i;
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/BrandEmbassyCodingStandard/Sniffs/Arrays/NestedArrayMultiline/NestedArrayMultilineSniffTest.php
+++ b/src/BrandEmbassyCodingStandard/Sniffs/Arrays/NestedArrayMultiline/NestedArrayMultilineSniffTest.php
@@ -1,0 +1,38 @@
+<?php declare(strict_types = 1);
+
+namespace BrandEmbassyCodingStandard\Sniffs\Arrays\NestedArrayMultiline;
+
+use PHPUnit\Framework\Assert;
+use SlevomatCodingStandard\Sniffs\TestCase;
+
+/**
+ * @final
+ */
+class NestedArrayMultilineSniffTest extends TestCase
+{
+    public function testCorrectFormattingProducesNoErrors(): void
+    {
+        $report = self::checkFile(__DIR__ . '/__fixtures__/correctFormatting.php');
+        self::assertNoSniffErrorInFile($report);
+    }
+
+
+    public function testNestedArraysAreFixed(): void
+    {
+        $report = self::checkFile(__DIR__ . '/__fixtures__/nestedArrays.php');
+
+        Assert::assertSame(9, $report->getErrorCount());
+
+        self::assertSniffError($report, 6, NestedArrayMultilineSniff::CODE_NESTED_NOT_MULTILINE);
+        self::assertSniffError($report, 9, NestedArrayMultilineSniff::CODE_NESTED_NOT_MULTILINE);
+        self::assertSniffError($report, 12, NestedArrayMultilineSniff::CODE_NESTED_NOT_MULTILINE);
+        self::assertSniffError($report, 12, NestedArrayMultilineSniff::CODE_NESTED_NOT_MULTILINE);
+        self::assertSniffError($report, 15, NestedArrayMultilineSniff::CODE_NESTED_NOT_MULTILINE);
+        self::assertSniffError($report, 18, NestedArrayMultilineSniff::CODE_NESTED_NOT_MULTILINE);
+        self::assertSniffError($report, 21, NestedArrayMultilineSniff::CODE_NESTED_NOT_MULTILINE);
+        self::assertSniffError($report, 24, NestedArrayMultilineSniff::CODE_NESTED_NOT_MULTILINE);
+        self::assertSniffError($report, 27, NestedArrayMultilineSniff::CODE_NESTED_NOT_MULTILINE);
+
+        self::assertAllFixedInFile($report);
+    }
+}

--- a/src/BrandEmbassyCodingStandard/Sniffs/Arrays/NestedArrayMultiline/__fixtures__/correctFormatting.php
+++ b/src/BrandEmbassyCodingStandard/Sniffs/Arrays/NestedArrayMultiline/__fixtures__/correctFormatting.php
@@ -1,0 +1,33 @@
+<?php declare(strict_types = 1);
+
+namespace BrandEmbassyCodingStandard\Sniffs\Arrays\NestedArrayMultiline\__fixtures__;
+
+// Empty arrays
+$empty = [];
+
+// Single element inline without nesting - not our concern
+$a = ['one'];
+
+// Multi element without nesting - not our concern
+$b = ['one', 'two'];
+
+// Nested arrays already multiline - correct
+$c = [
+    ['one'],
+    ['two'],
+];
+
+$d = [
+    'key' => ['nested'],
+];
+
+$e = [
+    'key' => [
+        'inner' => ['deep'],
+    ],
+];
+
+// Arrow function returning nested array - already multiline
+$f = [
+    fn() => ['nested'],
+];

--- a/src/BrandEmbassyCodingStandard/Sniffs/Arrays/NestedArrayMultiline/__fixtures__/nestedArrays.fixed.php
+++ b/src/BrandEmbassyCodingStandard/Sniffs/Arrays/NestedArrayMultiline/__fixtures__/nestedArrays.fixed.php
@@ -1,0 +1,49 @@
+<?php declare(strict_types = 1);
+
+namespace BrandEmbassyCodingStandard\Sniffs\Arrays\NestedArrayMultiline\__fixtures__;
+
+// Multi-element with nested arrays on single line
+$a = [
+    ['one'],
+    ['two'],
+];
+
+// Single element with nested array inline
+$b = [
+    'key' => ['nested'],
+];
+
+// Deeply nested arrays
+$c = [
+    'key' => [
+        'inner' => ['deep'],
+    ],
+];
+
+// Multi-element with nested array
+$d = [
+    'a',
+    ['b'],
+];
+
+// Multi keyed with nested values inline
+$e = [
+    'k1' => ['a'],
+    'k2' => ['b'],
+];
+
+// Mixed: some values plain, some nested
+$f = [
+    'k1' => 'v1',
+    'k2' => ['nested'],
+];
+
+// Single keyed, value is multi-element array
+$g = [
+    'key' => ['a', 'b'],
+];
+
+// Arrow function returning nested array on single line
+$h = [
+    fn() => ['nested'],
+];

--- a/src/BrandEmbassyCodingStandard/Sniffs/Arrays/NestedArrayMultiline/__fixtures__/nestedArrays.php
+++ b/src/BrandEmbassyCodingStandard/Sniffs/Arrays/NestedArrayMultiline/__fixtures__/nestedArrays.php
@@ -1,0 +1,27 @@
+<?php declare(strict_types = 1);
+
+namespace BrandEmbassyCodingStandard\Sniffs\Arrays\NestedArrayMultiline\__fixtures__;
+
+// Multi-element with nested arrays on single line
+$a = [['one'], ['two']];
+
+// Single element with nested array inline
+$b = ['key' => ['nested']];
+
+// Deeply nested arrays
+$c = ['key' => ['inner' => ['deep']]];
+
+// Multi-element with nested array
+$d = ['a', ['b']];
+
+// Multi keyed with nested values inline
+$e = ['k1' => ['a'], 'k2' => ['b']];
+
+// Mixed: some values plain, some nested
+$f = ['k1' => 'v1', 'k2' => ['nested']];
+
+// Single keyed, value is multi-element array
+$g = ['key' => ['a', 'b']];
+
+// Arrow function returning nested array on single line
+$h = [fn() => ['nested']];


### PR DESCRIPTION
Description: Add ECS sniff enforcing arrays with nested arrays to be multiline
Possible impact: Coding standard enforcement, array formatting

---
## Summary
Adds a new `NestedArrayMultilineSniff` that enforces arrays containing nested arrays (array within array) must be written in multiline format.

**Example:**
```php
// Before (error)
$a = ['key' => ['nested']];

// After (fixed)
$a = [
    'key' => ['nested'],
];
```

**Handles complex nesting:**
- Deeply nested arrays are expanded level by level across multiple fixer passes
- Inner single-element arrays remain inline (only the containing array is expanded)
- Works with arrow functions returning arrays, keyed arrays, mixed plain/nested values

## Changes
- **New sniff**: `NestedArrayMultilineSniff` with fixable error and auto-fixer
- **Tests**: Comprehensive test suite with correctFormatting and nestedArrays fixtures
- **Registered** in `default-ecs.php`
- No self-fixes needed (existing code already compliant)

This is part 3 of 3 - split from the combined ArrayFormattingSniff (PR #119):
1. SingleElementArrayInlineSniff
2. MultiElementArrayMultilineSniff
3. **NestedArrayMultilineSniff** (this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)