### PR TITLE
DE-161039 fix: PHP 8.4 rector fixes for coding-standard

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -31,22 +31,10 @@ parameters:
 			path: src/BrandEmbassyCodingStandard/Sniffs/Classes/TraitUseSpacingSniffTest.php
 
 		-
-			message: '#^Cannot cast mixed to string\.$#'
-			identifier: cast.string
-			count: 1
-			path: src/BrandEmbassyCodingStandard/Sniffs/Commenting/CreateMockFunctionReturnTypeOrderSniff.php
-
-		-
 			message: '#^Parameter \#4 \$startPointer of static method SlevomatCodingStandard\\Helpers\\TokenHelper\:\:findNextContent\(\) expects int, mixed given\.$#'
 			identifier: argument.type
 			count: 1
 			path: src/BrandEmbassyCodingStandard/Sniffs/Commenting/CreateMockFunctionReturnTypeOrderSniff.php
-
-		-
-			message: '#^Cannot cast mixed to string\.$#'
-			identifier: cast.string
-			count: 1
-			path: src/BrandEmbassyCodingStandard/Sniffs/ForbiddenElseStatementSniff.php
 
 		-
 			message: '#^Binary operation "\-" between mixed and 1 results in an error\.$#'

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -31,8 +31,8 @@ parameters:
 			path: src/BrandEmbassyCodingStandard/Sniffs/Classes/TraitUseSpacingSniffTest.php
 
 		-
-			message: '#^Parameter \#2 \$subject of function preg_match expects string, mixed given\.$#'
-			identifier: argument.type
+			message: '#^Cannot cast mixed to string\.$#'
+			identifier: cast.string
 			count: 1
 			path: src/BrandEmbassyCodingStandard/Sniffs/Commenting/CreateMockFunctionReturnTypeOrderSniff.php
 
@@ -43,8 +43,8 @@ parameters:
 			path: src/BrandEmbassyCodingStandard/Sniffs/Commenting/CreateMockFunctionReturnTypeOrderSniff.php
 
 		-
-			message: '#^Parameter \#1 \$string of function strtolower expects string, mixed given\.$#'
-			identifier: argument.type
+			message: '#^Cannot cast mixed to string\.$#'
+			identifier: cast.string
 			count: 1
 			path: src/BrandEmbassyCodingStandard/Sniffs/ForbiddenElseStatementSniff.php
 

--- a/src/BrandEmbassyCodingStandard/Sniffs/Commenting/CreateMockFunctionReturnTypeOrderSniff.php
+++ b/src/BrandEmbassyCodingStandard/Sniffs/Commenting/CreateMockFunctionReturnTypeOrderSniff.php
@@ -81,7 +81,7 @@ class CreateMockFunctionReturnTypeOrderSniff implements Sniff
 
         $returnType = $tokens[$returnTypePtr]['content'];
 
-        if (preg_match('~^MockInterface&(\w+)$~', $returnType, $matches) !== 1) {
+        if (preg_match('~^MockInterface&(\w+)$~', (string) $returnType, $matches) !== 1) {
             return;
         }
 

--- a/src/BrandEmbassyCodingStandard/Sniffs/Commenting/CreateMockFunctionReturnTypeOrderSniff.php
+++ b/src/BrandEmbassyCodingStandard/Sniffs/Commenting/CreateMockFunctionReturnTypeOrderSniff.php
@@ -81,7 +81,7 @@ class CreateMockFunctionReturnTypeOrderSniff implements Sniff
 
         $returnType = $tokens[$returnTypePtr]['content'];
 
-        if (preg_match('~^MockInterface&(\w+)$~', (string) $returnType, $matches) !== 1) {
+        if (preg_match('~^MockInterface&(\w+)$~', (string)$returnType, $matches) !== 1) {
             return;
         }
 

--- a/src/BrandEmbassyCodingStandard/Sniffs/Commenting/CreateMockFunctionReturnTypeOrderSniff.php
+++ b/src/BrandEmbassyCodingStandard/Sniffs/Commenting/CreateMockFunctionReturnTypeOrderSniff.php
@@ -5,6 +5,8 @@ namespace BrandEmbassyCodingStandard\Sniffs\Commenting;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Sniffs\Sniff;
 use SlevomatCodingStandard\Helpers\TokenHelper;
+use function assert;
+use function is_string;
 use function preg_match;
 use const T_FUNCTION;
 
@@ -80,8 +82,9 @@ class CreateMockFunctionReturnTypeOrderSniff implements Sniff
         }
 
         $returnType = $tokens[$returnTypePtr]['content'];
+        assert(is_string($returnType));
 
-        if (preg_match('~^MockInterface&(\w+)$~', (string)$returnType, $matches) !== 1) {
+        if (preg_match('~^MockInterface&(\w+)$~', $returnType, $matches) !== 1) {
             return;
         }
 

--- a/src/BrandEmbassyCodingStandard/Sniffs/ForbiddenElseStatementSniff.php
+++ b/src/BrandEmbassyCodingStandard/Sniffs/ForbiddenElseStatementSniff.php
@@ -37,7 +37,7 @@ class ForbiddenElseStatementSniff implements Sniff
     {
         $tokens = $phpcsFile->getTokens();
 
-        $statement = strtolower($tokens[$stackPtr]['content']);
+        $statement = strtolower((string) $tokens[$stackPtr]['content']);
 
         $error = 'Use of ' . $statement . ' is forbidden. See: https://github.com/BrandEmbassy/developers-manifest/issues/365.';
 

--- a/src/BrandEmbassyCodingStandard/Sniffs/ForbiddenElseStatementSniff.php
+++ b/src/BrandEmbassyCodingStandard/Sniffs/ForbiddenElseStatementSniff.php
@@ -4,6 +4,8 @@ namespace BrandEmbassyCodingStandard\Sniffs;
 
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Sniffs\Sniff;
+use function assert;
+use function is_string;
 use function strtolower;
 use const T_ELSE;
 use const T_ELSEIF;
@@ -37,7 +39,9 @@ class ForbiddenElseStatementSniff implements Sniff
     {
         $tokens = $phpcsFile->getTokens();
 
-        $statement = strtolower((string)$tokens[$stackPtr]['content']);
+        $content = $tokens[$stackPtr]['content'];
+        assert(is_string($content));
+        $statement = strtolower($content);
 
         $error = 'Use of ' . $statement . ' is forbidden. See: https://github.com/BrandEmbassy/developers-manifest/issues/365.';
 

--- a/src/BrandEmbassyCodingStandard/Sniffs/ForbiddenElseStatementSniff.php
+++ b/src/BrandEmbassyCodingStandard/Sniffs/ForbiddenElseStatementSniff.php
@@ -37,7 +37,7 @@ class ForbiddenElseStatementSniff implements Sniff
     {
         $tokens = $phpcsFile->getTokens();
 
-        $statement = strtolower((string) $tokens[$stackPtr]['content']);
+        $statement = strtolower((string)$tokens[$stackPtr]['content']);
 
         $error = 'Use of ' . $statement . ' is forbidden. See: https://github.com/BrandEmbassy/developers-manifest/issues/365.';
 


### PR DESCRIPTION
Description: PHP 8.4 backwards-compatible rector fixes for coding-standard
Possible impact: Code compatibility, string function null handling

---
## Summary
- Applies `NullToStrictStringFuncCallArgRector` (Category A, min_php 8.1) to add explicit `(string)` casts where nullable values are passed to string functions
- Fixes deprecation warnings for passing potentially null values to `preg_match()` and `strtolower()` in PHP 8.1+

## Files Changed
- `CreateMockFunctionReturnTypeOrderSniff.php` - Cast `$returnType` to string in `preg_match()` call
- `ForbiddenElseStatementSniff.php` - Cast token content to string in `strtolower()` call

## Skipped Rules (Category B or min_php > 8.1)
- `StringClassNameToClassConstantRector` (Cat B, min_php 5.5)
- `ClassPropertyAssignToConstructorPromotionRector` (Cat B, min_php 8.0)
- `ReadOnlyPropertyRector` (Cat B, min_php 8.1)
- `AddTypeToConstRector` (Cat B, min_php 8.3)
- `StrStartsWithRector` (Cat B, min_php 8.0)
- `StrEndsWithRector` (Cat B, min_php 8.0)

## Test Plan
- [x] Changes are minimal and backwards-compatible (explicit string cast)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)